### PR TITLE
Implemented Spec EqualIgnoreCase

### DIFF
--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/EqualIgnoreCase.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/EqualIgnoreCase.java
@@ -15,39 +15,35 @@
  */
 package net.kaczmarzyk.spring.data.jpa.domain;
 
+import net.kaczmarzyk.spring.data.jpa.utils.Converter;
+
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import net.kaczmarzyk.spring.data.jpa.utils.Converter;
-
 /**
  * <p>Filters with equal where-clause (e.g. {@code where firstName = "Homer"}).</p>
- * 
+ *
  * <p>Supports multiple field types: strings, numbers, booleans, enums, dates.</p>
- * 
- * @author Tomasz Kaczmarzyk
+ *
+ * <p>If the field type is string, the where-clause is case insensitive</p>
+ *
+ * @author Ricardo Pardinho
  */
-public class Equal<T> extends PathSpecification<T> {
+public class EqualIgnoreCase<T> extends Equal<T> {
 
-	protected String expectedValue;
-	private Converter converter;	
-	
-	
-	public Equal(String path, String[] httpParamValues, Converter converter) {
-		super(path);
-		if (httpParamValues == null || httpParamValues.length != 1) {
-			throw new IllegalArgumentException();
-		}
-		this.expectedValue = httpParamValues[0];
-		this.converter = converter;
-	}
-	
-	@Override
-	public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
-		Class<?> typeOnPath = path(root).getJavaType();
-		return cb.equal(path(root), converter.convert(expectedValue, typeOnPath));
-	}
+    public EqualIgnoreCase(String path, String[] httpParamValues, Converter converter) {
+        super(path, httpParamValues, converter);
+    }
 
+    @Override
+    public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+
+        if (path(root).getJavaType().equals(String.class)) {
+            return cb.equal(cb.upper(this.<String>path(root)), expectedValue.toUpperCase());
+        }
+
+        return super.toPredicate(root, query, cb);
+    }
 }

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EqualIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EqualIgnoreCaseTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.domain;
+
+import net.kaczmarzyk.spring.data.jpa.Customer;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Ricardo Pardinho
+ */
+public class EqualIgnoreCaseTest extends EqualTest {
+
+    @Test
+    public void filtersByStringCaseInsensitive() {
+        EqualIgnoreCase<Customer> simpsons = new EqualIgnoreCase<>("lastName", new String[] { "SIMpsOn" }, defaultConverter);
+        List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
+
+        assertThat(simpsonsFound).hasSize(2).containsOnly(homerSimpson, margeSimpson);
+
+
+        EqualIgnoreCase<Customer> lastNameS = new EqualIgnoreCase<>("lastName", new String[] { "s" }, defaultConverter);
+        List<Customer> found = customerRepo.findAll(lastNameS);
+
+        assertThat(found).isEmpty();
+
+
+        EqualIgnoreCase<Customer> firstName = new EqualIgnoreCase<>("firstName", new String[] { "Moe" }, defaultConverter);
+        List<Customer> moeFound = customerRepo.findAll(firstName);
+
+        assertThat(moeFound).hasSize(1).containsOnly(moeSzyslak);
+    }
+
+    
+}

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EqualTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EqualTest.java
@@ -39,10 +39,10 @@ import net.kaczmarzyk.spring.data.jpa.web.annotation.OnTypeMismatch;
  */
 public class EqualTest extends IntegrationTestBase {
 
-    private Customer homerSimpson;
-    private Customer margeSimpson;
-    private Customer moeSzyslak;
-    private Customer joeQuimby;
+    protected Customer homerSimpson;
+    protected Customer margeSimpson;
+    protected Customer moeSzyslak;
+    protected Customer joeQuimby;
 
     @Before
     public void initData() {


### PR DESCRIPTION
Implemented an EqualIgnoreCase spec that behaves exactly the same than Equal but ignores case when the field type is a String.