### PR TITLE
added ability to pass boolean param to IsNull spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ Usage: `@Spec(path="gender", spec=In.class)`.
 
 The default date format used for temporal fields is `yyyy-MM-dd`. It can be overriden with a configuration parameter (see `LessThan` below).
 
-### IsNull ###
+### Null ###
 
-Does not use any HTTP-parameters. Represents static `where` clause: `path is null`.
+Filters using `is null` or `is not null`, depending on the value of the parameter passed in. A value of `true` will filter for `is null`, and a value of `false` will filter for `is not null`.
 
-Usage: `@Spec(path="activationDate", spec=IsNull.class)`.
+The data type of the field specified in `path` can be anything, but the HTTP parameter must be a Boolean. You should use `params` attribute to make it clear that the parameter is filtering for null values.
+
+Usage: `@Spec(path="activationDate", params="activationDateNull" spec=Null.class)`.
 
 ### GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual ###
 

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/Null.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/Null.java
@@ -15,6 +15,8 @@
  */
 package net.kaczmarzyk.spring.data.jpa.domain;
 
+import net.kaczmarzyk.spring.data.jpa.utils.Converter;
+
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
@@ -22,24 +24,34 @@ import javax.persistence.criteria.Root;
 
 
 /**
- * <p>Filers with "is null" where clause (e.g. {@code where nickName is null}).</p>
+ * <p>Filers with "is null" or "is not null" where clause (e.g. {@code where nickName is null}).</p>
  *
- * <p>Does not require any http-parameters to be present, i.e. represents constant part of the query.</p>
+ * <p>Requires boolean parameter.</p>
  *
  * @author Tomasz Kaczmarzyk
- *
- * @deprecated Consider using {@link net.kaczmarzyk.spring.data.jpa.domain.Null Null}
+ * @author Gerald Humphries
  */
-@Deprecated
-public class IsNull<T> extends PathSpecification<T> implements ZeroArgSpecification {
+public class Null<T> extends PathSpecification<T> {
 
-	public IsNull(String path, String[] args) {
+	protected String expectedValue;
+	private Converter converter;
+
+	public Null(String path, String[] httpParamValues, Converter converter) {
 		super(path);
+		if (httpParamValues == null || httpParamValues.length != 1) {
+			throw new IllegalArgumentException();
+		}
+		this.expectedValue = httpParamValues[0];
+		this.converter = converter;
 	}
 
 	@Override
 	public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
-		return cb.isNull(path(root));
+		if (converter.convert(expectedValue, Boolean.class)) {
+			return cb.isNull(path(root));
+		} else {
+			return cb.isNotNull(path(root));
+		}
 	}
 
 }

--- a/src/test/java/net/kaczmarzyk/NullE2eTest.java
+++ b/src/test/java/net/kaczmarzyk/NullE2eTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk;
+
+import net.kaczmarzyk.spring.data.jpa.Customer;
+import net.kaczmarzyk.spring.data.jpa.CustomerRepository;
+import net.kaczmarzyk.spring.data.jpa.domain.Null;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+public class NullE2eTest extends E2eTestBase {
+
+	@Controller
+	public static class TestController {
+
+		@Autowired
+		CustomerRepository customerRepo;
+
+		@RequestMapping("/characters")
+		@ResponseBody
+		public Object findCharacters(
+				@Spec(path = "nickName", params = "nickNameNull", spec = Null.class) Specification<Customer> spec) {
+			return customerRepo.findAll(spec);
+		}
+	}
+
+	@Test
+	public void findsEntitiesWithNullAttributeValue() throws Exception {
+		mockMvc.perform(get("/characters?nickNameNull=true")
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").isArray())
+				.andExpect(jsonPath("$[?(@.firstName=='Marge')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Lisa')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Maggie')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Moe')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Homer')]").doesNotExist())
+				.andExpect(jsonPath("$[?(@.firstName=='Bart')]").doesNotExist())
+				.andExpect(jsonPath("$[?(@.firstName=='Ned')]").doesNotExist())
+				.andExpect(jsonPath("$[5]").doesNotExist());
+	}
+
+	@Test
+	public void findsEntitiesWithNotNullAttributeValue() throws Exception {
+		mockMvc.perform(get("/characters?nickNameNull=false")
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").isArray())
+				.andExpect(jsonPath("$[?(@.firstName=='Marge')]").doesNotExist())
+				.andExpect(jsonPath("$[?(@.firstName=='Lisa')]").doesNotExist())
+				.andExpect(jsonPath("$[?(@.firstName=='Maggie')]").doesNotExist())
+				.andExpect(jsonPath("$[?(@.firstName=='Moe')]").doesNotExist())
+				.andExpect(jsonPath("$[?(@.firstName=='Homer')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Bart')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Ned')]").exists())
+				.andExpect(jsonPath("$[4]").doesNotExist());
+	}
+
+	@Test
+	public void findsEntitiesWithNoFiltering() throws Exception {
+		mockMvc.perform(get("/characters")
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").isArray())
+				.andExpect(jsonPath("$[?(@.firstName=='Marge')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Lisa')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Maggie')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Moe')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Homer')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Bart')]").exists())
+				.andExpect(jsonPath("$[?(@.firstName=='Ned')]").exists());
+	}
+}

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NullTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NullTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.domain;
+
+import net.kaczmarzyk.spring.data.jpa.Customer;
+import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * @author Tomasz Kaczmarzyk
+ * @author Gerald Humphries
+ */
+public class NullTest extends IntegrationTestBase {
+
+	Customer bartSimpson;
+	Customer lisaSimpson;
+
+	@Before
+	public void initData() {
+		bartSimpson = customer("Bart", "Simpson").nickName("El Barto").street("Evergreen Terrace").build(em);
+		lisaSimpson = customer("Lisa", "Simpson").registrationDate(2014, 03, 20).street("Evergreen Terrace").build(em);
+	}
+
+	@Test
+	public void findsCustomersWithNullField() {
+		Null<Customer> spec = new Null<>("nickName", new String[]{"true"}, defaultConverter);
+
+		List<Customer> found = customerRepo.findAll(spec);
+
+		assertThat(found).hasSize(1).containsOnly(lisaSimpson);
+	}
+
+	@Test
+	public void findsCustomersWithNotNullField() {
+		Null<Customer> spec = new Null<>("nickName", new String[]{"false"}, defaultConverter);
+
+		List<Customer> found = customerRepo.findAll(spec);
+
+		assertThat(found).hasSize(1).containsOnly(bartSimpson);
+	}
+}


### PR DESCRIPTION
This allows you to construct a Specification like this: `@Spec(path = "number", params="numberNull", spec = IsNull.class)`

Passing `numberNull=true` will find entities where number is null. `numberNull=false` will find entities where number is not null. Leaving the param out will ignore it. This gives API users a lot more flexibility when dealing with null values.

`@Spec(path = "number", spec = IsNull.class, constVal="true")` matches the old functionality.

I think this should be a new spec called `Null` and `IsNull` should be deprecated.