### PR TITLE
Added a NotNull class to provide inverse behavior of Null class

### DIFF
--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/NotNull.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/NotNull.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.domain;
+
+import net.kaczmarzyk.spring.data.jpa.utils.Converter;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+/**
+ * <p>Filers with "is null" or "is not null" where clause (e.g. {@code where nickName is not null}).
+ *  This file is the inverse of Null.java</p>
+ *
+ * <p>Requires boolean parameter.</p>
+ *
+ * @author Steven McLaughlin
+ */
+public class NotNull<T> extends PathSpecification<T> {
+
+    protected String expectedValue;
+    private Converter converter;
+
+    public NotNull(String path, String[] httpParamValues, Converter converter) {
+        super(path);
+        if (httpParamValues == null || httpParamValues.length != 1) {
+            throw new IllegalArgumentException();
+        }
+        this.expectedValue = httpParamValues[0];
+        this.converter = converter;
+    }
+
+    @Override
+    public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+        if (converter.convert(expectedValue, Boolean.class)) {
+            return cb.isNotNull(path(root));
+        } else {
+            return cb.isNull(path(root));
+        }
+    }
+
+}

--- a/src/test/java/net/kaczmarzyk/NotNullE2eTest.java
+++ b/src/test/java/net/kaczmarzyk/NotNullE2eTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk;
+
+import net.kaczmarzyk.spring.data.jpa.Customer;
+import net.kaczmarzyk.spring.data.jpa.CustomerRepository;
+import net.kaczmarzyk.spring.data.jpa.domain.NotNull;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+public class NotNullE2eTest extends E2eTestBase {
+
+    @Controller
+    public static class TestController {
+
+        @Autowired
+        CustomerRepository customerRepo;
+
+        @RequestMapping("/characters")
+        @ResponseBody
+        public Object findCharacters(
+                                        @Spec(path = "nickName", params = "nickName", spec = NotNull.class) Specification<Customer> spec) {
+            return customerRepo.findAll(spec);
+        }
+    }
+
+    @Test
+    public void findsEntitiesWithNotNullAttributeValue() throws Exception {
+        mockMvc.perform(get("/characters?nickName=true")
+                            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$[?(@.firstName=='Marge')]").doesNotExist())
+            .andExpect(jsonPath("$[?(@.firstName=='Lisa')]").doesNotExist())
+            .andExpect(jsonPath("$[?(@.firstName=='Maggie')]").doesNotExist())
+            .andExpect(jsonPath("$[?(@.firstName=='Moe')]").doesNotExist())
+            .andExpect(jsonPath("$[?(@.firstName=='Homer')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Bart')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Ned')]").exists())
+            .andExpect(jsonPath("$[5]").doesNotExist());
+    }
+
+    @Test
+    public void findsEntitiesWithNullAttributeValue() throws Exception {
+        mockMvc.perform(get("/characters?nickName=false")
+                            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$[?(@.firstName=='Marge')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Lisa')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Maggie')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Moe')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Homer')]").doesNotExist())
+            .andExpect(jsonPath("$[?(@.firstName=='Bart')]").doesNotExist())
+            .andExpect(jsonPath("$[?(@.firstName=='Ned')]").doesNotExist())
+            .andExpect(jsonPath("$[4]").doesNotExist());
+    }
+
+    @Test
+    public void findsEntitiesWithNoFiltering() throws Exception {
+        mockMvc.perform(get("/characters")
+                            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$[?(@.firstName=='Marge')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Lisa')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Maggie')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Moe')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Homer')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Bart')]").exists())
+            .andExpect(jsonPath("$[?(@.firstName=='Ned')]").exists());
+    }
+}

--- a/src/test/java/net/kaczmarzyk/NotNullE2eTest.java
+++ b/src/test/java/net/kaczmarzyk/NotNullE2eTest.java
@@ -40,17 +40,17 @@ public class NotNullE2eTest extends E2eTestBase {
         @Autowired
         CustomerRepository customerRepo;
 
-        @RequestMapping("/characters")
+        @RequestMapping("/simpsons")
         @ResponseBody
-        public Object findCharacters(
+        public Object findCharactersTest(
                                         @Spec(path = "nickName", params = "nickName", spec = NotNull.class) Specification<Customer> spec) {
             return customerRepo.findAll(spec);
         }
     }
 
     @Test
-    public void findsEntitiesWithNotNullAttributeValue() throws Exception {
-        mockMvc.perform(get("/characters?nickName=true")
+    public void findsEntitiesWithNickname() throws Exception {
+        mockMvc.perform(get("/simpsons?nickName=true")
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").isArray())
@@ -65,8 +65,8 @@ public class NotNullE2eTest extends E2eTestBase {
     }
 
     @Test
-    public void findsEntitiesWithNullAttributeValue() throws Exception {
-        mockMvc.perform(get("/characters?nickName=false")
+    public void findsEntitiesWithNoNickname() throws Exception {
+        mockMvc.perform(get("/simpsons?nickName=false")
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").isArray())
@@ -81,8 +81,8 @@ public class NotNullE2eTest extends E2eTestBase {
     }
 
     @Test
-    public void findsEntitiesWithNoFiltering() throws Exception {
-        mockMvc.perform(get("/characters")
+    public void findsAllEntities() throws Exception {
+        mockMvc.perform(get("/simpsons")
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").isArray())

--- a/src/test/java/net/kaczmarzyk/NotNullE2eTest.java
+++ b/src/test/java/net/kaczmarzyk/NotNullE2eTest.java
@@ -40,9 +40,9 @@ public class NotNullE2eTest extends E2eTestBase {
         @Autowired
         CustomerRepository customerRepo;
 
-        @RequestMapping("/simpsons")
+        @RequestMapping("/family")
         @ResponseBody
-        public Object findCharactersTest(
+        public Object findCharacters(
                                         @Spec(path = "nickName", params = "nickName", spec = NotNull.class) Specification<Customer> spec) {
             return customerRepo.findAll(spec);
         }
@@ -50,7 +50,7 @@ public class NotNullE2eTest extends E2eTestBase {
 
     @Test
     public void findsEntitiesWithNickname() throws Exception {
-        mockMvc.perform(get("/simpsons?nickName=true")
+        mockMvc.perform(get("/family?nickName=true")
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").isArray())
@@ -66,7 +66,7 @@ public class NotNullE2eTest extends E2eTestBase {
 
     @Test
     public void findsEntitiesWithNoNickname() throws Exception {
-        mockMvc.perform(get("/simpsons?nickName=false")
+        mockMvc.perform(get("/family?nickName=false")
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").isArray())
@@ -82,7 +82,7 @@ public class NotNullE2eTest extends E2eTestBase {
 
     @Test
     public void findsAllEntities() throws Exception {
-        mockMvc.perform(get("/simpsons")
+        mockMvc.perform(get("/family")
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").isArray())

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotNullTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotNullTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.domain;
+
+import net.kaczmarzyk.spring.data.jpa.Customer;
+import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * @author Steven McLaughlin
+ */
+public class NotNullTest extends IntegrationTestBase {
+
+    Customer bartSimpson;
+    Customer lisaSimpson;
+
+    @Before
+    public void initData() {
+        bartSimpson = customer("Bart", "Simpson").nickName("El Barto").street("Evergreen Terrace").build(em);
+        lisaSimpson = customer("Lisa", "Simpson").registrationDate(2014, 03, 20).street("Evergreen Terrace").build(em);
+    }
+
+    @Test
+    public void findsCustomersWithNotNullField() {
+        NotNull<Customer> spec = new NotNull<>("nickName", new String[]{"true"}, defaultConverter);
+
+        List<Customer> found = customerRepo.findAll(spec);
+
+        assertThat(found).hasSize(1).containsOnly(bartSimpson);
+    }
+
+    @Test
+    public void findsCustomersWithNullField() {
+        NotNull<Customer> spec = new NotNull<>("nickName", new String[]{"false"}, defaultConverter);
+
+        List<Customer> found = customerRepo.findAll(spec);
+
+        assertThat(found).hasSize(1).containsOnly(lisaSimpson);
+    }
+}


### PR DESCRIPTION
I added this for readability. If there is already a simple way to do this, please let me know. I thought this may help others. 

My use case:
I have an object I need to filter on a field called "isDeleted". My server stores this as "deletedDate". Deleted date will be null when the entity is not deleted, and vice-versa. I don't want the front-end to know about the back-end's implementation, so I don't want to force the front end to call the endpoint with an "isDeletedNull" parameter, but rather an "isDeleted" parameter. 

I want my endpoint to look like /api/entity?isDeleted=true rather than /api/entity?isDeletedNull=false