### PR TITLE
Fix spring-boot reflection for JDK17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
 		 	 <dependency>
 	            <groupId>org.springframework.boot</groupId>
 	            <artifactId>spring-boot-dependencies</artifactId>
-	            <version>2.1.2.RELEASE</version>
+	            <version>2.6.4</version>
 	            <type>pom</type>
 	            <scope>import</scope>
 	        </dependency>

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/EnhancerUtil.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/EnhancerUtil.java
@@ -15,12 +15,12 @@
  */
 package net.kaczmarzyk.spring.data.jpa.web;
 
-import java.lang.reflect.Method;
-
 import org.springframework.cglib.proxy.Enhancer;
 import org.springframework.cglib.proxy.MethodInterceptor;
 import org.springframework.cglib.proxy.MethodProxy;
 import org.springframework.data.jpa.domain.Specification;
+
+import java.lang.reflect.Method;
 
 
 /**
@@ -31,7 +31,7 @@ class EnhancerUtil {
     @SuppressWarnings("unchecked")
 	static <T> T wrapWithIfaceImplementation(final Class<T> iface, final Specification<Object> targetSpec) {
     	Enhancer enhancer = new Enhancer();
-		enhancer.setInterfaces(new Class[] { iface });
+		enhancer.setSuperclass(iface);
 		enhancer.setCallback(new MethodInterceptor() {
             @Override
             public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/EnhancerUtil.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/EnhancerUtil.java
@@ -17,10 +17,7 @@ package net.kaczmarzyk.spring.data.jpa.web;
 
 import org.springframework.cglib.proxy.Enhancer;
 import org.springframework.cglib.proxy.MethodInterceptor;
-import org.springframework.cglib.proxy.MethodProxy;
 import org.springframework.data.jpa.domain.Specification;
-
-import java.lang.reflect.Method;
 
 
 /**
@@ -32,15 +29,12 @@ class EnhancerUtil {
 	static <T> T wrapWithIfaceImplementation(final Class<T> iface, final Specification<Object> targetSpec) {
     	Enhancer enhancer = new Enhancer();
 		enhancer.setSuperclass(iface);
-		enhancer.setCallback(new MethodInterceptor() {
-            @Override
-            public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {
-            	if ("toString".equals(method.getName())) {
-            		return iface.getSimpleName() + "[" + proxy.invoke(targetSpec, args) + "]";
-            	}
-            	return proxy.invoke(targetSpec, args);
-            }
-        });
+		enhancer.setCallback((MethodInterceptor) (obj, method, args, proxy) -> {
+			if ("toString".equals(method.getName())) {
+				return iface.getSimpleName() + "[" + method.invoke(targetSpec, args) + "]";
+			}
+			return proxy.invoke(targetSpec, args);
+		});
 		
 		return (T) enhancer.create();
     }

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/ConverterFallbackMechanismTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/ConverterFallbackMechanismTest.java
@@ -48,28 +48,28 @@ public class ConverterFallbackMechanismTest {
 	public void shouldNotUseFallbackMechanismForEnumType() {
 		converter.convert("MALE", Gender.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForDateType() {
 		converter.convert("2015-03-01", Date.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForLocalDateType() {
 		converter.convert("2020-06-19", LocalDate.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForLocalDateTimeType() {
 		converter.convert("2020-06-19T16:50:49", LocalDateTime.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
@@ -77,7 +77,7 @@ public class ConverterFallbackMechanismTest {
 		converter.convert("true", Boolean.class);
 		converter.convert("false", Boolean.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
@@ -85,91 +85,91 @@ public class ConverterFallbackMechanismTest {
 		converter.convert("true", boolean.class);
 		converter.convert("false", boolean.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForIntegerType() {
 		converter.convert("1", Integer.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForIntegerPrimitiveType() {
 		converter.convert("1", int.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForLongType() {
 		converter.convert("1", Long.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForLongPrimitveType() {
 		converter.convert("1", long.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForFloatType() {
 		converter.convert("10", Float.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForFloatPrimitiveType() {
 		converter.convert("10.8", float.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForDoubleType() {
 		converter.convert("13.52", Double.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForDoublePrimitiveType() {
 		converter.convert("13.53", double.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForBigDecimalType() {
 		converter.convert("13.54", BigDecimal.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForUUIDType() {
 		converter.convert("2cdf7f82-2e32-4219-be0c-a5457e79c7b1", UUID.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForOffsetDateTimeType() {
 		converter.convert("2020-06-16T15:08:53.282+02:00", OffsetDateTime.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test
 	public void shouldNotUseFallbackMechanismForInstantType() {
 		converter.convert("2020-06-16T15:08:53.282Z", Instant.class);
 		
-		verifyZeroInteractions(conversionService);
+		verifyNoInteractions(conversionService);
 	}
 	
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/ResolverTestBase.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/ResolverTestBase.java
@@ -58,14 +58,14 @@ public abstract class ResolverTestBase {
 
 	protected Collection<Specification<Object>> innerSpecs(Specification<?> resolvedSpec) {
 		net.kaczmarzyk.spring.data.jpa.domain.Conjunction<Object> resolvedConjunction =
-				ReflectionUtils.get(ReflectionUtils.get(resolvedSpec, "CGLIB$CALLBACK_0"), "val$targetSpec");
+				ReflectionUtils.get(ReflectionUtils.get(resolvedSpec, "CGLIB$CALLBACK_0"), "arg$2");
 
 		return ReflectionUtils.get(resolvedConjunction, "innerSpecs");
 	}
 
 	protected Collection<Specification<Object>> innerSpecsFromDisjunction(Specification<?> resolvedSpec) {
 		net.kaczmarzyk.spring.data.jpa.domain.Disjunction<Object> resolvedDisjunction =
-				ReflectionUtils.get(ReflectionUtils.get(resolvedSpec, "CGLIB$CALLBACK_0"), "val$targetSpec");
+				ReflectionUtils.get(ReflectionUtils.get(resolvedSpec, "CGLIB$CALLBACK_0"), "arg$2");
 
 		return ReflectionUtils.get(resolvedDisjunction, "innerSpecs");
 	}


### PR DESCRIPTION
Checkout the referenced issue for more details. 
This seems to bring back the expected functionality and works with JDK 17. 

Tests run fine with:

```text
OpenJDK Runtime Environment Temurin-17.0.2+8 (build 17.0.2+8)
```

<img width="1374" alt="grafik" src="https://user-images.githubusercontent.com/25681388/157449428-f5970e45-bb56-429a-9cd8-42dd970a25c4.png">


Minimal adjustments to make tests pass with upgraded spring-boot version (currently latest) and dperecation fixes.