### PR TITLE
Added json support for SpecificationBuilder

### DIFF
--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/SpecificationBuilder.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/SpecificationBuilder.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 /**
  * SpecificationBuilder allows creating specification apart from web layer.
- * It is recommended to use builder methods that corresponding to the type of argument passed to sepcification.
+ * It is recommended to use builder methods that corresponding to the type of argument passed to specification.
  * <ul>
  * <li> {@code params = <args> => withParams(<argName>, <values...>)}, single param argument can provide multiple values </li>
  * <li> {@code pathVars = <args> => withPathVar(<argName>, <value>)}, single pathVar argument can provide single value </li>
@@ -45,6 +45,7 @@ public class SpecificationBuilder<T extends Specification> {
 	private Map<String, String> pathVars = new HashMap<>();
 	private Map<String, String[]> params = new HashMap<>();
 	private Map<String, String> headers = new HashMap<>();
+	private Map<String, String[]> bodyParams = new HashMap<>();
 
 	private SpecificationBuilder(Class<T> specInterface) {
 		this.specInterface = specInterface;
@@ -84,13 +85,18 @@ public class SpecificationBuilder<T extends Specification> {
 		return this;
 	}
 
+	public SpecificationBuilder<T> withJsonBodyParam(String jsonPath, String... values) {
+		this.bodyParams.put(jsonPath, values);
+		return this;
+	}
+
 	public T build() {
 		ProcessingContext context = createContext();
 		return (T) specificationFactory.createSpecificationDependingOn(context);
 	}
 
 	private ProcessingContext createContext() {
-		return new StandaloneProcessingContext(specInterface, fallbackSpecificationParamValues, pathVars, params, headers);
+		return new StandaloneProcessingContext(specInterface, fallbackSpecificationParamValues, pathVars, params, headers, bodyParams);
 	}
 
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/ProcessingContext.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/ProcessingContext.java
@@ -15,7 +15,6 @@
  */
 package net.kaczmarzyk.spring.data.jpa.web;
 
-import net.kaczmarzyk.spring.data.jpa.utils.BodyParams;
 import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 
 import java.lang.annotation.Annotation;
@@ -34,5 +33,5 @@ public interface ProcessingContext {
 
 	String getPathVariableValue(String pathVariableName);
 
-	BodyParams getBodyParams();
+	String[] getBodyParamValues(String bodyParamName);
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolver.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolver.java
@@ -16,7 +16,6 @@
 package net.kaczmarzyk.spring.data.jpa.web;
 
 import net.kaczmarzyk.spring.data.jpa.domain.ZeroArgSpecification;
-import net.kaczmarzyk.spring.data.jpa.utils.BodyParams;
 import net.kaczmarzyk.spring.data.jpa.utils.Converter;
 import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
@@ -34,7 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -191,13 +190,12 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 		}
 		return args;
 	}
-  
-  private Collection<String> resolveSpecArgumentsFromBody(ProcessingContext context, Spec specDef) {
-		BodyParams bodyParams = context.getBodyParams();
-        return Arrays.stream(specDef.jsonPaths())
-            .flatMap(param -> bodyParams.getParamValues(param).stream())
-            .collect(toList());
-    }
+
+	private Collection<String> resolveSpecArgumentsFromBody(ProcessingContext context, Spec specDef) {
+		return Arrays.stream(specDef.jsonPaths())
+				.flatMap(param -> nullSafeArrayStream(context.getBodyParamValues(param)))
+				.collect(toList());
+	}
 
 	private Collection<String> resolveSpecArgumentsFromRequestHeaders(ProcessingContext context, Spec specDef) {
 		Collection<String> args = new ArrayList<>();
@@ -246,6 +244,10 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 				}
 			}
 		}
+	}
+
+	private Stream<String> nullSafeArrayStream(String[] array) {
+		return array != null ? Stream.of(array) : Stream.empty();
 	}
 	
 	private static class DelimitationStrategy {

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/StandaloneProcessingContext.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/StandaloneProcessingContext.java
@@ -15,7 +15,6 @@
  */
 package net.kaczmarzyk.spring.data.jpa.web;
 
-import net.kaczmarzyk.spring.data.jpa.utils.BodyParams;
 import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 
 import java.lang.annotation.Annotation;
@@ -39,6 +38,7 @@ public class StandaloneProcessingContext implements ProcessingContext {
 	private Map<String, String> pathVariableArgs;
 	private Map<String, String[]> parameterArgs;
 	private Map<String, String> headerArgs;
+	private Map<String, String[]> bodyParams;
 
 	private QueryContext queryContext;
 
@@ -46,12 +46,14 @@ public class StandaloneProcessingContext implements ProcessingContext {
 									   Map<String, String[]> fallbackArgumentValues,
 									   Map<String, String> pathVariableArgs,
 									   Map<String, String[]> parameterArgs,
-									   Map<String, String> headerArgs) {
+									   Map<String, String> headerArgs,
+									   Map<String, String[]> bodyParams) {
 		this.specInterface = specInterface;
 		this.fallbackArgumentValues = fallbackArgumentValues;
 		this.pathVariableArgs = pathVariableArgs;
 		this.parameterArgs = parameterArgs;
 		this.headerArgs = headerArgs;
+		this.bodyParams = bodyParams;
 		this.queryContext = new DefaultQueryContext();
 	}
 
@@ -96,6 +98,11 @@ public class StandaloneProcessingContext implements ProcessingContext {
 		}
 	}
 
+	@Override
+	public String[] getBodyParamValues(String bodyParamName) {
+		return bodyParams.containsKey(bodyParamName) ? bodyParams.get(bodyParamName) : getFallbackValues(bodyParamName);
+	}
+
 	private String[] getFallbackValues(String argName) {
 		return fallbackArgumentValues.get(argName);
 	}
@@ -105,10 +112,5 @@ public class StandaloneProcessingContext implements ProcessingContext {
 			return null;
 		}
 		return fallbackArgumentValues.get(argName)[0];
-	}
-
-	@Override
-	public BodyParams getBodyParams() {
-		throw new UnsupportedOperationException("todo");
 	}
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/WebRequestProcessingContext.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/WebRequestProcessingContext.java
@@ -31,8 +31,6 @@ import static java.util.Objects.isNull;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import static java.util.Objects.isNull;
-
 /**
  * Provides information about Controller/method and WebRequest being processed.
  * It is a wrapper around low-level Spring classes, which provides easier access to e.g. path variables.
@@ -89,24 +87,17 @@ public class WebRequestProcessingContext implements ProcessingContext {
 		}
 	}
 
-  public String getRequestBody() {
-		try {
-			HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-			if (request == null) {
-				throw new IllegalStateException("Request body not present");
-			}
-			return IOUtils.toString(request.getInputStream(), StandardCharsets.UTF_8);
-		} catch (IOException ex) {
-			throw new RuntimeException("Cannot read request body. Detail: " + ex.getMessage());
-		}
-	}
-
 	@Override
 	public String getRequestHeaderValue(String headerKey) {
 		return webRequest.getHeader(headerKey);
 	}
 
-	public BodyParams getBodyParams() {
+	@Override
+	public String[] getBodyParamValues(String bodyParamName) {
+		return getBodyParams().getParamValues(bodyParamName).toArray(new String[0]);
+	}
+
+	private BodyParams getBodyParams() {
 		if (isNull(bodyParams)) {
 			String contentType = getRequestHeaderValue(CONTENT_TYPE);
 			if (contentType.equals(APPLICATION_JSON_VALUE)) {
@@ -116,6 +107,18 @@ public class WebRequestProcessingContext implements ProcessingContext {
 			}
 		}
 		return bodyParams;
+	}
+
+	private String getRequestBody() {
+		try {
+			HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+			if (request == null) {
+				throw new IllegalStateException("Request body not present");
+			}
+			return IOUtils.toString(request.getInputStream(), StandardCharsets.UTF_8);
+		} catch (IOException ex) {
+			throw new RuntimeException("Cannot read request body. Detail: " + ex.getMessage());
+		}
 	}
 
 	private String pathPattern() {

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/StandaloneProcessingContextTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/StandaloneProcessingContextTest.java
@@ -37,18 +37,21 @@ public class StandaloneProcessingContextTest {
 		Map<String, String[]> params = new HashMap<>();
 		Map<String, String> pathVars = new HashMap<>();
 		Map<String, String> headers = new HashMap<>();
+		Map<String, String[]> bodyParams = new HashMap<>();
 
 		args.put("fallback", new String[]{"example"});
 		params.put("param", new String[]{"example"});
 		pathVars.put("pathVar", "example");
 		headers.put("header", "example");
+		bodyParams.put("bodyParam", new String[]{"example"});
 
 		context = new StandaloneProcessingContext(
 				null,
 				args,
 				pathVars,
 				params,
-				headers);
+				headers,
+				bodyParams);
 	}
 
 	@Test
@@ -56,10 +59,12 @@ public class StandaloneProcessingContextTest {
 		String fallbackValueForPathVariable = context.getPathVariableValue("fallback");
 		String[] fallbackValueForParams = context.getParameterValues("fallback");
 		String fallbackValueForHeader = context.getRequestHeaderValue("fallback");
+		String[] fallbackValueForJsonPath = context.getBodyParamValues("fallback");
 
 		assertThat(fallbackValueForPathVariable).isEqualTo("example");
 		assertThat(fallbackValueForParams).isEqualTo(new String[]{"example"});
 		assertThat(fallbackValueForHeader).isEqualTo("example");
+		assertThat(fallbackValueForJsonPath).isEqualTo(new String[]{"example"});
 	}
 
 	@Test
@@ -92,4 +97,13 @@ public class StandaloneProcessingContextTest {
 		assertThat(context.getRequestHeaderValue("notExisting")).isNull();
 	}
 
+	@Test
+	public void shouldReturnBodyParamValue() {
+		assertThat(context.getBodyParamValues("bodyParam")).containsExactly("example");
+	}
+
+	@Test
+	public void shouldReturnNullWhenBodyParamDoesNotExist() {
+		assertThat(context.getBodyParamValues("notExisting")).isNull();
+	}
 }


### PR DESCRIPTION
- added method signature in `ProcessingContext` -  `getBodyParamValues` (new method with String[] return type to keep compatibility with the rest returning params methods)
- removed method signature from `ProcessingContext` - `getBodyParams`
- added json path support for `SpecificationBuilder`