### PR TITLE
Fixed media type check for getBodyParams

### DIFF
--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/WebRequestProcessingContext.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/WebRequestProcessingContext.java
@@ -17,6 +17,7 @@ package net.kaczmarzyk.spring.data.jpa.web;
 
 import net.kaczmarzyk.spring.data.jpa.utils.*;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 
 import javax.servlet.http.HttpServletRequest;
@@ -27,7 +28,8 @@ import java.util.Map;
 
 import static java.util.Objects.isNull;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.parseMediaType;
 
 /**
  *
@@ -98,7 +100,8 @@ public class WebRequestProcessingContext implements ProcessingContext {
 	private BodyParams getBodyParams() {
 		if (isNull(bodyParams)) {
 			String contentType = getRequestHeaderValue(CONTENT_TYPE);
-			if (contentType.equals(APPLICATION_JSON_VALUE)) {
+			MediaType mediaType = parseMediaType(contentType);
+			if (APPLICATION_JSON.includes(mediaType)) {
 				this.bodyParams = JsonBodyParams.parse(getRequestBody());
 			} else {
 				throw new IllegalArgumentException("Content-type not supported, content-type=" + contentType);

--- a/src/test/java/net/kaczmarzyk/RequestBodyHandlingE2eTest.java
+++ b/src/test/java/net/kaczmarzyk/RequestBodyHandlingE2eTest.java
@@ -100,6 +100,18 @@ public class RequestBodyHandlingE2eTest extends E2eTestBase {
     }
 
     @Test
+    public void findsByIdProvidedInRequestBodyWhenContentTypeContainsParameter() throws Exception {
+        mockMvc.perform(post("/customers/search")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON_VALUE + ";encoding=UTF-8")
+                            .content(" { \"customerId\": \"" + homerSimpson.getId() + "\" }"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$").isArray())
+               .andExpect(jsonPath("$.length()").value(1))
+               .andExpect(jsonPath("$[0].firstName").value(homerSimpson.getFirstName()));
+    }
+
+    @Test
     public void returnsBadRequestWhenContentBodyContainsArrayJsonNode() throws Exception {
         mockMvc.perform(post("/customers/search/firstName")
                         .accept(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
When `Content-Type` header contains parameter (such as `application/json;encoding=UTF-8`) we unable to resolve request arguments for json body - throws `IllegalArgumentException` with `Content-type not supported, content-type=application/json;encoding=UTF-8` message

