### PR TITLE
Fixed redundant proxy creation for multi-spec specifications when expected type is not a spec-interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v2.15.1
 ======
 * updated spring-boot-dependencies to 2.7.7
 * fixed potential issue with detecting non-emmpty HTTP headers
+* fixed redundant proxy creation for multi-spec specifications when expected type is not a spec-interface
 
 v2.15.0
 =======

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
@@ -68,7 +68,7 @@ public class SpecificationFactory {
 
 		Specification<Object> spec = specs.size() == 1 ? specs.iterator().next() : new net.kaczmarzyk.spring.data.jpa.domain.Conjunction<>(specs);
 
-		if (Specification.class == context.getParameterType()) {
+		if (context.getParameterType().isAssignableFrom(Specification.class)) {
 			return spec;
 		} else {
 			return (Specification<?>) EnhancerUtil.wrapWithIfaceImplementation(context.getParameterType(), spec);

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
@@ -68,7 +68,7 @@ public class SpecificationFactory {
 
 		Specification<Object> spec = specs.size() == 1 ? specs.iterator().next() : new net.kaczmarzyk.spring.data.jpa.domain.Conjunction<>(specs);
 
-		if (context.getParameterType().isAssignableFrom(Specification.class)) {
+		if (context.getParameterType().isAssignableFrom(spec.getClass())) {
 			return spec;
 		} else {
 			return (Specification<?>) EnhancerUtil.wrapWithIfaceImplementation(context.getParameterType(), spec);

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
@@ -66,19 +66,13 @@ public class SpecificationFactory {
 			return null;
 		}
 
-		if (specs.size() == 1) {
-			Specification<Object> firstSpecification = specs.iterator().next();
+		Specification<Object> spec = specs.size() == 1 ? specs.iterator().next() : new net.kaczmarzyk.spring.data.jpa.domain.Conjunction<>(specs);
 
-			if (Specification.class == context.getParameterType()) {
-				return firstSpecification;
-			} else {
-				return (Specification<?>) EnhancerUtil.wrapWithIfaceImplementation(context.getParameterType(), firstSpecification);
-			}
+		if (Specification.class == context.getParameterType()) {
+			return spec;
+		} else {
+			return (Specification<?>) EnhancerUtil.wrapWithIfaceImplementation(context.getParameterType(), spec);
 		}
-
-		Specification<Object> spec = new net.kaczmarzyk.spring.data.jpa.domain.Conjunction<>(specs);
-
-		return (Specification<?>) EnhancerUtil.wrapWithIfaceImplementation(context.getParameterType(), spec);
 	}
 
 	private List<Specification<Object>> resolveSpec(ProcessingContext context) {

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedAndSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedAndSpecInterfaceArgumentResolverTest.java
@@ -91,7 +91,7 @@ public class AnnotatedAndSpecInterfaceArgumentResolverTest extends AnnotatedSpec
 		assertThat(resolved)
 				.isInstanceOf(GenderLastNameAndSpec.class);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(2)
 				.containsExactlyInAnyOrder(
 						new EmptyResultOnTypeMismatch<>(equal(ctx, "gender", "MALE")),
@@ -119,7 +119,7 @@ public class AnnotatedAndSpecInterfaceArgumentResolverTest extends AnnotatedSpec
 		assertThat(resolved)
 				.isInstanceOf(EmptyFilterExtendingTwoInterfacesWithAndFilter.class);
 
-		Collection<Specification<Object>> innerSpecs = innerSpecs(resolved);
+		Collection<Specification<Object>> innerSpecs = proxiedInnerSpecs(resolved);
 
 		assertThat(innerSpecs)
 				.hasSize(3)

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedConjunctionSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedConjunctionSpecInterfaceArgumentResolverTest.java
@@ -19,7 +19,6 @@ import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.domain.*;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Or;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.jpa.domain.Specification;
@@ -29,7 +28,6 @@ import java.util.Collection;
 
 import static net.kaczmarzyk.spring.data.jpa.web.utils.NativeWebRequestBuilder.nativeWebRequest;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * Test cases:
@@ -93,7 +91,7 @@ public class AnnotatedConjunctionSpecInterfaceArgumentResolverTest extends Annot
 		assertThat(resolved)
 				.isInstanceOf(GenderOrLastNameAndRegistrationDateFilter.class);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(2)
 				.containsExactlyInAnyOrder(
 						new Disjunction<>(
@@ -125,7 +123,7 @@ public class AnnotatedConjunctionSpecInterfaceArgumentResolverTest extends Annot
 		assertThat(resolved)
 				.isInstanceOf(EmptyFilterExtendingTwoInterfacesWithConjunctionFilter.class);
 
-		Collection<Specification<Object>> innerSpecs = innerSpecs(resolved);
+		Collection<Specification<Object>> innerSpecs = proxiedInnerSpecs(resolved);
 
 		assertThat(innerSpecs)
 				.hasSize(3)

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedDisjunctionSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedDisjunctionSpecInterfaceArgumentResolverTest.java
@@ -126,7 +126,7 @@ public class AnnotatedDisjunctionSpecInterfaceArgumentResolverTest extends Annot
 		assertThat(resolved)
 				.isInstanceOf(SpecExtendedByTwoOtherDisjunctionFilters.class);
 
-		Collection<Specification<Object>> innerSpecs = innerSpecs(resolved);
+		Collection<Specification<Object>> innerSpecs = proxiedInnerSpecs(resolved);
 
 		Assertions.assertThat(innerSpecs)
 				.hasSize(3)

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedJoinFetchSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedJoinFetchSpecInterfaceArgumentResolverTest.java
@@ -95,7 +95,7 @@ public class AnnotatedJoinFetchSpecInterfaceArgumentResolverTest extends Annotat
 		assertThat(resolved)
 				.isInstanceOf(OrderedItemNameFilter.class);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(2)
 				.containsExactlyInAnyOrder(
 						new JoinFetch<>(queryCtx, new String[]{ "orders" }, LEFT, true),
@@ -125,7 +125,7 @@ public class AnnotatedJoinFetchSpecInterfaceArgumentResolverTest extends Annotat
 		assertThat(resolved)
 				.isInstanceOf(SpecExtendedByTwoOtherJoinFetchFilters.class);
 
-		Collection<Specification<Object>> innerSpecs = innerSpecs(resolved);
+		Collection<Specification<Object>> innerSpecs = proxiedInnerSpecs(resolved);
 
 		Assertions.assertThat(innerSpecs)
 				.hasSize(6)

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedJoinSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedJoinSpecInterfaceArgumentResolverTest.java
@@ -20,7 +20,6 @@ import net.kaczmarzyk.spring.data.jpa.domain.*;
 import net.kaczmarzyk.spring.data.jpa.domain.Conjunction;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.*;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Join;
-import net.kaczmarzyk.utils.ReflectionUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.core.MethodParameter;
@@ -96,7 +95,7 @@ public class AnnotatedJoinSpecInterfaceArgumentResolverTest extends AnnotatedSpe
 		assertThat(resolved)
 				.isInstanceOf(OrderedItemNameFilter.class);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(2)
 				.containsExactlyInAnyOrder(
 						new net.kaczmarzyk.spring.data.jpa.domain.Join<>(ctx.queryContext(), "orders", "o", LEFT, true),
@@ -125,7 +124,7 @@ public class AnnotatedJoinSpecInterfaceArgumentResolverTest extends AnnotatedSpe
 		assertThat(resolved)
 				.isInstanceOf(SpecExtendedByTwoOtherJoinSpecsFilter.class);
 
-		Collection<Specification<Object>> innerSpecs = innerSpecs(resolved);
+		Collection<Specification<Object>> innerSpecs = proxiedInnerSpecs(resolved);
 
 		Assertions.assertThat(innerSpecs)
 				.hasSize(6)

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedJoinsSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedJoinsSpecInterfaceArgumentResolverTest.java
@@ -19,7 +19,6 @@ import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.domain.*;
 import net.kaczmarzyk.spring.data.jpa.domain.Conjunction;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.*;
-import net.kaczmarzyk.utils.ReflectionUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.core.MethodParameter;
@@ -27,14 +26,12 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.web.context.request.NativeWebRequest;
 
 import javax.persistence.criteria.JoinType;
-import java.util.Collection;
 
 import static javax.persistence.criteria.JoinType.INNER;
 import static javax.persistence.criteria.JoinType.LEFT;
 import static net.kaczmarzyk.spring.data.jpa.web.utils.NativeWebRequestBuilder.nativeWebRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Test cases:
@@ -102,7 +99,7 @@ public class AnnotatedJoinsSpecInterfaceArgumentResolverTest extends AnnotatedSp
 		assertThat(resolved)
 				.isInstanceOf(OrderedItemNameFilter.class);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(2)
 				.containsExactlyInAnyOrder(
 						new Conjunction<>(
@@ -134,7 +131,7 @@ public class AnnotatedJoinsSpecInterfaceArgumentResolverTest extends AnnotatedSp
 		assertThat(resolved)
 				.isInstanceOf(SpecExtendedByTwoOtherInterfacesWithJoinsFilter.class);
 
-		Assertions.assertThat(innerSpecs(resolved))
+		Assertions.assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(6)
 				.containsOnly(
 						new Conjunction<>(new net.kaczmarzyk.spring.data.jpa.domain.Join<>(ctx.queryContext(), "badges", "b", JoinType.INNER, true)),

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedOrSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedOrSpecInterfaceArgumentResolverTest.java
@@ -118,7 +118,7 @@ public class AnnotatedOrSpecInterfaceArgumentResolverTest extends AnnotatedSpecI
 		assertThat(resolved)
 				.isInstanceOf(SpecExtendedByTwoOtherOrSpecs.class);
 
-		Collection<Specification<Object>> innerSpecs = innerSpecs(resolved);
+		Collection<Specification<Object>> innerSpecs = proxiedInnerSpecs(resolved);
 
 		Assertions.assertThat(innerSpecs)
 				.hasSize(3)

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedRepeatedJoinFetchSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedRepeatedJoinFetchSpecInterfaceArgumentResolverTest.java
@@ -96,7 +96,7 @@ public class AnnotatedRepeatedJoinFetchSpecInterfaceArgumentResolverTest extends
 
 		Specification<?> resolved = (Specification<?>) specificationArgumentResolver.resolveArgument(param, null, req, null);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(2)
 				.containsExactlyInAnyOrder(
 						new JoinFetch<>(queryCtx, new String[]{ "orders" }, LEFT, true),
@@ -120,7 +120,7 @@ public class AnnotatedRepeatedJoinFetchSpecInterfaceArgumentResolverTest extends
 
 		Specification<?> resolved = (Specification<?>) specificationArgumentResolver.resolveArgument(param, null, req, null);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(3)
 				.containsExactlyInAnyOrder(
 						new Conjunction<>(
@@ -146,7 +146,7 @@ public class AnnotatedRepeatedJoinFetchSpecInterfaceArgumentResolverTest extends
 
 		Specification<?> resolved = (Specification<?>) specificationArgumentResolver.resolveArgument(param, null, req, null);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(2)
 				.containsExactlyInAnyOrder(
 						new Conjunction<>(

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedRepeatedJoinSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedRepeatedJoinSpecInterfaceArgumentResolverTest.java
@@ -107,7 +107,7 @@ public class AnnotatedRepeatedJoinSpecInterfaceArgumentResolverTest extends Anno
 
 		Specification<?> resolved = (Specification<?>) specificationArgumentResolver.resolveArgument(param, null, req, null);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(2)
 				.containsExactlyInAnyOrder(
 						new Conjunction<>(
@@ -135,7 +135,7 @@ public class AnnotatedRepeatedJoinSpecInterfaceArgumentResolverTest extends Anno
 
 		Specification<?> resolved = (Specification<?>) specificationArgumentResolver.resolveArgument(param, null, req, null);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(4)
 				.containsExactlyInAnyOrder(
 						new Conjunction<>(
@@ -166,7 +166,7 @@ public class AnnotatedRepeatedJoinSpecInterfaceArgumentResolverTest extends Anno
 
 		Specification<?> resolved = (Specification<?>) specificationArgumentResolver.resolveArgument(param, null, req, null);
 
-		assertThat(innerSpecs(resolved))
+		assertThat(proxiedInnerSpecs(resolved))
 				.hasSize(4)
 				.containsExactlyInAnyOrder(
 						new Conjunction<>(

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedSpecInterfaceArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedSpecInterfaceArgumentResolverTest.java
@@ -237,7 +237,7 @@ public class AnnotatedSpecInterfaceArgumentResolverTest extends AnnotatedSpecInt
 
 		Specification<?> resolved = (Specification<?>) resolver.resolveArgument(param, null, req, null);
 
-		Collection<Specification<Object>> resolvedInnerSpecs = innerSpecs(resolved);
+		Collection<Specification<Object>> resolvedInnerSpecs = proxiedInnerSpecs(resolved);
 		assertThat(resolvedInnerSpecs)
 				.hasSize(4)
 				.containsOnly(

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedSpecInterfaceWithComplexInheritanceTreeTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedSpecInterfaceWithComplexInheritanceTreeTest.java
@@ -211,7 +211,7 @@ public class AnnotatedSpecInterfaceWithComplexInheritanceTreeTest extends Annota
 		assertThat(resolved)
 				.isInstanceOf(JoinFilter.class);
 
-		Collection<Specification<Object>> resolvedInnerSpecs = innerSpecs(resolved);
+		Collection<Specification<Object>> resolvedInnerSpecs = proxiedInnerSpecs(resolved);
 		assertThat(resolvedInnerSpecs)
 				.hasSize(10)
 				.containsOnly(

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/ProxyGenerationStrategyTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/ProxyGenerationStrategyTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.web;
+
+import net.kaczmarzyk.spring.data.jpa.domain.Like;
+import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Conjunction;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Join;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Or;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
+import net.kaczmarzyk.utils.ReflectionUtils;
+import org.junit.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import javax.persistence.criteria.JoinType;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ProxyGenerationStrategyTest extends ResolverTestBase {
+
+    SpecificationArgumentResolver resolver = new SpecificationArgumentResolver();
+
+    @Test
+    public void proxyShouldNotBeGeneratedWhenMethodParameterIsAnnotatedWithSingleSpecification() throws Exception {
+        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethod_singleInnerSpec"), 0);
+        NativeWebRequest req = mock(NativeWebRequest.class);
+        QueryContext queryCtx = new DefaultQueryContext();
+        when(req.getParameterValues("path1")).thenReturn(new String[] { "value1" });
+
+        Specification<?> resolved = (Specification<?>) resolver.resolveArgument(param, null, req, null);
+
+        assertThatSpecIsNotProxy(resolved);
+
+        assertThat(resolved)
+                .isEqualTo(new Like<>(queryCtx, "path1", new String[] { "value1" }));
+    }
+
+    @Test
+    public void proxyShouldNotBeGeneratedWhenMethodParameterIsAnnotatedWithMultipleSpecifications() throws Exception {
+        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethod_multipleInnerSpecs"), 0);
+        NativeWebRequest req = mock(NativeWebRequest.class);
+        QueryContext queryCtx = new DefaultQueryContext();
+        when(req.getParameterValues("path1")).thenReturn(new String[] { "value1" });
+
+        Specification<?> resolved = (Specification<?>) resolver.resolveArgument(param, null, req, null);
+
+        assertThatSpecIsNotProxy(resolved);
+
+        assertThat(innerSpecs(resolved))
+                .hasSize(2)
+                .contains(new net.kaczmarzyk.spring.data.jpa.domain.Join<>(queryCtx, "join1", "alias1", JoinType.LEFT, true))
+                .contains(new Like<>(queryCtx, "path1", new String[]{"value1"}));
+    }
+
+    @Test
+    public void proxyShouldNotBeGeneratedWhenMethodParameterIsAnnotatedWithConjunctionWithMultipleInnerSpecs() throws Exception {
+        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethod_conjunctionWithMultipleInnerSpecs"), 0);
+        NativeWebRequest req = mock(NativeWebRequest.class);
+        QueryContext queryCtx = new DefaultQueryContext();
+        when(req.getParameterValues("path1")).thenReturn(new String[] { "value1" });
+        when(req.getParameterValues("path2")).thenReturn(new String[] { "value2" });
+
+        Specification<?> resolved = (Specification<?>) resolver.resolveArgument(param, null, req, null);
+
+        assertThatSpecIsNotProxy(resolved);
+
+        List<Specification<?>> resolvedDisjunction = ReflectionUtils.get(resolved, "innerSpecs");
+
+        assertThat(innerSpecs(resolvedDisjunction.get(0)))
+                .hasSize(2)
+                .contains(
+                        new Like<>(queryCtx, "path1", new String[] { "value1" }),
+                        new Like<>(queryCtx, "path2", new String[] { "value2" })
+                );
+    }
+
+    @Test
+    public void proxyShouldBeGeneratedWhenMethodParameterIsInterface_isAnnotatedWithMultipleInnerSpecs() throws Exception {
+        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethod_interfaceSpecificationAsMethodParameter", CustomSpecification.class), 0);
+        NativeWebRequest req = mock(NativeWebRequest.class);
+        QueryContext queryCtx = new DefaultQueryContext();
+        when(req.getParameterValues("path1")).thenReturn(new String[] { "value1" });
+        when(req.getParameterValues("path2")).thenReturn(new String[] { "value2" });
+
+        Specification<?> resolved = (Specification<?>) resolver.resolveArgument(param, null, req, null);
+
+        assertThatSpecIsProxy(resolved);
+
+        assertThat(proxiedInnerSpecs(resolved))
+                .hasSize(2)
+                .contains(new net.kaczmarzyk.spring.data.jpa.domain.Join<>(queryCtx, "join1", "alias1", JoinType.LEFT, true))
+                .contains(new Like<>(queryCtx, "path1", new String[]{ "value1" }));
+    }
+
+    @Override
+    protected Class<?> controllerClass() {
+        return TestController.class;
+    }
+
+    @Join(path = "join1", alias = "alias1", type = JoinType.LEFT)
+    @Spec(path = "path1", spec = Like.class)
+    public interface CustomSpecification extends Specification<Object> {}
+
+    public static class TestController {
+
+        public void testMethod_singleInnerSpec(
+                @Spec(path = "path1", spec = Like.class) Specification<Object> spec) {
+        }
+
+        public void testMethod_multipleInnerSpecs(
+                @Join(path = "join1", alias = "alias1", type = JoinType.LEFT, distinct = true)
+                @Spec(path = "path1", spec = Like.class) Specification<Object> spec) {
+        }
+
+        public void testMethod_conjunctionWithMultipleInnerSpecs(
+                @Conjunction(
+                        @Or({
+                                @Spec(path = "path1", spec = Like.class),
+                                @Spec(path = "path2", spec = Like.class)
+                        })) Specification<Object> spec) {
+        }
+
+        public void testMethod_interfaceSpecificationAsMethodParameter(
+                CustomSpecification spec) {
+        }
+
+    }
+
+}

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/ResolverTestBase.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/ResolverTestBase.java
@@ -18,13 +18,14 @@ package net.kaczmarzyk.spring.data.jpa.web;
 import net.kaczmarzyk.spring.data.jpa.utils.Converter;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.OnTypeMismatch;
 import net.kaczmarzyk.utils.ReflectionUtils;
+import org.springframework.cglib.proxy.Enhancer;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.lang.reflect.Executable;
 import java.util.Collection;
 
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -56,6 +57,10 @@ public abstract class ResolverTestBase {
 		);
     }
 
+	protected Collection<Specification<Object>> innerSpecsWithoutProxy(Specification<?> resolvedSpec) {
+		return ReflectionUtils.get(resolvedSpec, "innerSpecs");
+	}
+
 	protected Collection<Specification<Object>> innerSpecs(Specification<?> resolvedSpec) {
 		net.kaczmarzyk.spring.data.jpa.domain.Conjunction<Object> resolvedConjunction =
 				ReflectionUtils.get(ReflectionUtils.get(resolvedSpec, "CGLIB$CALLBACK_0"), "arg$2");
@@ -71,4 +76,12 @@ public abstract class ResolverTestBase {
 	}
 
 	protected abstract Class<?> controllerClass();
+
+	protected void assertThatSpecIsProxy(Specification<?> specification) {
+		assertThat(Enhancer.isEnhanced(specification.getClass())).isTrue();
+	}
+
+	protected void assertThatSpecIsNotProxy(Specification<?> specification) {
+		assertThat(Enhancer.isEnhanced(specification.getClass())).isFalse();
+	}
 }

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/ResolverTestBase.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/ResolverTestBase.java
@@ -57,11 +57,11 @@ public abstract class ResolverTestBase {
 		);
     }
 
-	protected Collection<Specification<Object>> innerSpecsWithoutProxy(Specification<?> resolvedSpec) {
+	protected Collection<Specification<Object>> innerSpecs(Specification<?> resolvedSpec) {
 		return ReflectionUtils.get(resolvedSpec, "innerSpecs");
 	}
 
-	protected Collection<Specification<Object>> innerSpecs(Specification<?> resolvedSpec) {
+	protected Collection<Specification<Object>> proxiedInnerSpecs(Specification<?> resolvedSpec) {
 		net.kaczmarzyk.spring.data.jpa.domain.Conjunction<Object> resolvedConjunction =
 				ReflectionUtils.get(ReflectionUtils.get(resolvedSpec, "CGLIB$CALLBACK_0"), "arg$2");
 

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationArgumentResolverTest.java
@@ -22,7 +22,6 @@ import net.kaczmarzyk.spring.data.jpa.web.annotation.Join;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.JoinFetch;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Joins;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
-import net.kaczmarzyk.spring.data.jpa.web.annotation.Or;
 import org.junit.Test;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.jpa.domain.Specification;
@@ -50,7 +49,7 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
 
         assertThatSpecIsNotProxy(resolved);
 
-        assertThat(innerSpecsWithoutProxy(resolved))
+        assertThat(innerSpecs(resolved))
             .hasSize(2)
             .contains(new Like<Object>(queryCtx, "path1", new String[] { "value1" }))
             .contains(new net.kaczmarzyk.spring.data.jpa.domain.JoinFetch<Object>(queryCtx, new String[] { "fetch1", "fetch2" }, JoinType.LEFT, true));
@@ -67,7 +66,7 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
 
         assertThatSpecIsNotProxy(resolved);
 
-        assertThat(innerSpecsWithoutProxy(resolved))
+        assertThat(innerSpecs(resolved))
             .hasSize(2)
             .contains(new Like<>(queryCtx, "path1", new String[]{ "value1" }))
             .contains(new Conjunction<>(
@@ -86,7 +85,7 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
 
         assertThatSpecIsNotProxy(resolved);
 
-        assertThat(innerSpecsWithoutProxy(resolved))
+        assertThat(innerSpecs(resolved))
             .hasSize(2)
             .contains(new Like<Object>(queryCtx, "path1", new String[] { "value1" }))
             .contains(new Conjunction<Object>(
@@ -105,7 +104,7 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
 
         assertThatSpecIsNotProxy(resolved);
 
-        assertThat(innerSpecsWithoutProxy(resolved))
+        assertThat(innerSpecs(resolved))
             .hasSize(2)
             .contains(new Like<Object>(queryCtx, "path1", new String[] { "value1" }))
             .contains(new Conjunction<Object>(
@@ -124,7 +123,7 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
 
         assertThatSpecIsNotProxy(resolved);
 
-        assertThat(innerSpecsWithoutProxy(resolved))
+        assertThat(innerSpecs(resolved))
             .hasSize(2)
             .contains(new Like<Object>(queryCtx, "path1", new String[] { "value1" }))
             .contains(new Conjunction<Object>(
@@ -159,7 +158,7 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
 
         assertThatSpecIsProxy(resolved);
 
-        assertThat(innerSpecs(resolved))
+        assertThat(proxiedInnerSpecs(resolved))
                 .hasSize(2)
                 .contains(new Like<Object>(queryCtx, "path1", new String[] { "value1" }))
                 .contains(new net.kaczmarzyk.spring.data.jpa.domain.JoinFetch<Object>(queryCtx, new String[] { "fetch1", "fetch2" }, JoinType.LEFT, true));
@@ -176,7 +175,7 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
 
         assertThatSpecIsProxy(resolved);
 
-        assertThat(innerSpecs(resolved))
+        assertThat(proxiedInnerSpecs(resolved))
                 .hasSize(2)
                 .contains(new Like<>(queryCtx, "path1", new String[]{ "value1" }))
                 .contains(new Conjunction<>(
@@ -199,7 +198,7 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
         assertThat(resolved)
             .isInstanceOf(CustomSpecJoinContainer.class);
 
-        assertThat(innerSpecs(resolved))
+        assertThat(proxiedInnerSpecs(resolved))
                 .hasSize(2)
                 .contains(
                         new Conjunction<>(
@@ -232,14 +231,6 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
     })
     @Spec(path = "path1", spec = Like.class)
     public static interface CustomSpecJoinContainer extends Specification<Object> {
-    }
-
-    @net.kaczmarzyk.spring.data.jpa.web.annotation.Conjunction(
-            @Or(
-                    @Spec(path = "path1", spec = Like.class)
-            )
-    )
-    public static interface ConjunctionSpec extends Specification<Object> {
     }
     
     public static class TestController {

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationArgumentResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationArgumentResolverTest.java
@@ -290,14 +290,5 @@ public class SpecificationArgumentResolverTest extends ResolverTestBase {
                     })
                 @Spec(path = "path1", spec = Like.class) Specification<Object> spec) {
         }
-
-        public void testMethod_conjunctionWithOrAndSingleSpec(
-                @net.kaczmarzyk.spring.data.jpa.web.annotation.Conjunction(
-                        @Or(
-                                @Spec(path = "path1", spec = Like.class)
-                        )
-                ) Specification<Object> spec) {
-
-        }
     }
 }


### PR DESCRIPTION
#162 