### PR TITLE
Fixed typos and implemented minor test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ v2.16.0
 v2.15.1
 ======
 * updated spring-boot-dependencies to 2.7.7
-* fixed potential issue with detecting non-emmpty HTTP headers
+* fixed potential issue with detecting non-empty HTTP headers
 * fixed redundant proxy creation for multi-spec specifications when expected type is not a spec-interface
 
 v2.15.0
@@ -127,7 +127,7 @@ v2.11.0
   * To create specifications outside the web layer, you can use the specification builder as follows:
     ```java
     Specification<Customer> spec = SpecificationBuilder.specification(CustomerByOrdersSpec.class) // good candidate for static import
-          .withParams("orderItem", "Pizza")
+          .withParam("orderItem", "Pizza")
           .build();            
     ```
   * It is recommended to use builder methods that corresponding to the type of argument passed to specification interface, e.g.:
@@ -135,8 +135,8 @@ v2.11.0
     ```java
     @Spec(paths = "o.itemName", params = "orderItem", spec=Like.class)
     ``` 
-    you should use `withparams(<argName>, <values...>)` method. Each argument type (param, header, path variable) has its own corresponding builder method:
-    * `params = <args>` => `withParams(<argName>, <values...>)`, single param argument can provide multiple values
+    you should use `withParam(<argName>, <values...>)` method. Each argument type (param, header, path variable) has its own corresponding builder method:
+    * `params = <args>` => `withParam(<argName>, <values...>)`, single param argument can provide multiple values
     * `pathVars = <args>` => `withPathVar(<argName>, <value>)`, single pathVar argument can provide single value
     * `headers = <args>` => `withHeader(<argName>, <value>)`, single header argument can provide single value
 

--- a/README.md
+++ b/README.md
@@ -1299,7 +1299,7 @@ To build specification outside the web-layer the `SpecificationBuilder` should b
     * To create specifications outside the web layer, you can use the specification builder as follows:
       ```java
       Specification<Customer> spec = SpecificationBuilder.specification(CustomerByOrdersSpec.class) // good candidate for static import
-            .withParams("orderItem", "Pizza")
+            .withParam("orderItem", "Pizza")
             .build();            
       ```
     * It is recommended to use builder methods that corresponding to the type of argument type passed to specification interface, e.g.:
@@ -1307,8 +1307,8 @@ To build specification outside the web-layer the `SpecificationBuilder` should b
       ```java
       @Spec(paths = "o.itemName", params = "orderItem", spec=Like.class)
       ``` 
-      you should use `withparams(<argName>, <values...>)` method. Each argument type (param, header, path variable) has its own corresponding builder method:
-        * `params = <args>` => `withParams(<argName>, <values...>)`, single param argument can provide multiple values
+      you should use `withParam(<argName>, <values...>)` method. Each argument type (param, header, path variable) has its own corresponding builder method:
+        * `params = <args>` => `withParam(<argName>, <values...>)`, single param argument can provide multiple values
         * `pathVars = <args>` => `withPathVar(<argName>, <value>)`, single pathVar argument can provide single value
         * `headers = <args>` => `withHeader(<argName>, <value>)`, single header argument can provide single value
 

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/SpecificationBuilder.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/SpecificationBuilder.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * SpecificationBuilder allows creating specification apart from web layer.
  * It is recommended to use builder methods that corresponding to the type of argument passed to specification.
  * <ul>
- * <li> {@code params = <args> => withParams(<argName>, <values...>)}, single param argument can provide multiple values </li>
+ * <li> {@code params = <args> => withParam(<argName>, <values...>)}, single param argument can provide multiple values </li>
  * <li> {@code pathVars = <args> => withPathVar(<argName>, <value>)}, single pathVar argument can provide single value </li>
  * <li> {@code headers = <args> => withHeader(<argName>, <value>)}, single header argument can provide single value </li>
  * </ul>

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EqualDayTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EqualDayTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.domain;
+
+import com.jparams.verifier.tostring.ToStringVerifier;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class EqualDayTest {
+
+	@Test
+	public void equalsAndHashCodeContract() {
+		EqualsVerifier.forClass(EqualDay.class)
+			.usingGetClass()
+			.suppress(Warning.NONFINAL_FIELDS)
+			.verify();
+	}
+
+	@Test
+	public void toStringVerifier() {
+		ToStringVerifier.forClass(EqualDay.class)
+			.withIgnoredFields("queryContext")
+			.verify();
+	}
+}


### PR DESCRIPTION
* Added missing test for equals and hashcode contract for `EqualDay` specification
* Fixed typo in examples of usage (`README`, `CHANGELOG`, javadocs) of `withParam` method from `SpecificationBuilder`: `withParams(...)` => `withParam(...)` 