### PR TITLE
Updated `springdoc-openapi` dependency for migration to spring boot 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ v3.0.0
   * Spring boot 3.0 is based on Hibernate version 6.X because in this version of hibernate all query results are distinct by default. This shouldn't affect most projects, but please be extra careful if you've ever used a spec with the `distinct=false` attribute.
 * Added support for spring native-image.
   * Specification-arg-resolver can be used in GraalVM native images, but it requires several additional configuration steps. This is due to the fact that this library relies on Java reflection heavily. Please see [README_native_image.md](README_native_image.md) for the details
+* Modified Springdoc-openapi dependency to be compatible with spring boot 3.0
 
 v2.16.0
 =======

--- a/README.md
+++ b/README.md
@@ -1164,14 +1164,22 @@ Swagger support
 Right now specification argument resolver supports only one library -> `Springdoc-openapi`.
 
 There are two steps in order to enable support for `Springdoc-openapi` library:
-* Add following dependency from `Springdoc-openapi` (tested with `1.6.13` version):
-```xml
-<dependency>
-    <groupId>org.springdoc</groupId>
-    <artifactId>springdoc-openapi-common</artifactId>
-</dependency>
-```
-
+* Add dependency from `Springdoc-openapi`:
+  * For dependencies older than `specification-arg-resolver 3.0.0`, please use `springdoc-openapi-common` (tested with `1.6.13` version):
+    ```xml
+    <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-common</artifactId>
+    </dependency>
+    ```
+  * For `specification-arg-resolver 3.0.0` and newer, please use `springdoc-openapi-starter-common` (tested with `2.0.2` version):
+    ```xml
+    <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-starter-common</artifactId>
+    </dependency>
+    ```
+    
 * Create `@Bean` of type `SpecificationArgResolverSpringdocOperationCustomizer` in your app configuration:
 ```java
 @Bean

--- a/README.md
+++ b/README.md
@@ -1165,7 +1165,7 @@ Right now specification argument resolver supports only one library -> `Springdo
 
 There are two steps in order to enable support for `Springdoc-openapi` library:
 * Add dependency from `Springdoc-openapi`:
-  * For dependencies older than `specification-arg-resolver 3.0.0`, please use `springdoc-openapi-common` (tested with `1.6.13` version):
+  * For versions older than `specification-arg-resolver 3.0.0`, please use `springdoc-openapi-common` (tested with `1.6.13` version):
     ```xml
     <dependency>
         <groupId>org.springdoc</groupId>

--- a/README.md
+++ b/README.md
@@ -1165,18 +1165,18 @@ Right now specification argument resolver supports only one library -> `Springdo
 
 There are two steps in order to enable support for `Springdoc-openapi` library:
 * Add dependency from `Springdoc-openapi`:
-  * For versions older than `specification-arg-resolver 3.0.0`, please use `springdoc-openapi-common` (tested with `1.6.13` version):
-    ```xml
-    <dependency>
-        <groupId>org.springdoc</groupId>
-        <artifactId>springdoc-openapi-common</artifactId>
-    </dependency>
-    ```
   * For `specification-arg-resolver 3.0.0` and newer, please use `springdoc-openapi-starter-common` (tested with `2.0.2` version):
     ```xml
     <dependency>
         <groupId>org.springdoc</groupId>
         <artifactId>springdoc-openapi-starter-common</artifactId>
+    </dependency>
+    ```
+  * For versions older than `specification-arg-resolver 3.0.0`, please use `springdoc-openapi-common` (tested with `1.6.13` version):
+    ```xml
+    <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-common</artifactId>
     </dependency>
     ```
     

--- a/pom.xml
+++ b/pom.xml
@@ -239,8 +239,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-common</artifactId>
-			<version>1.6.14</version>
+			<artifactId>springdoc-openapi-starter-common</artifactId>
+			<version>2.0.2</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/swagger/springdoc/SpecificationArgResolverSpringdocOperationCustomizer.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/swagger/springdoc/SpecificationArgResolverSpringdocOperationCustomizer.java
@@ -39,8 +39,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.springdoc.core.SpringDocUtils;
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.web.bind.annotation.RequestMapping;


### PR DESCRIPTION
This Pull Request is related to issue with migration to spring boot 3.0 => https://github.com/tkaczmarzyk/specification-arg-resolver/issues/140