### PR TITLE
Fixed `InTheFuture` and `InThePast` specifications for 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v2.18.1
+=======
+* Fixed a bug related to specifications that always returned all available values. Fixed specs:
+  * `InThePast`
+  * `InTheFuture`
+
 v2.18.0
 =======
 * Introduced `IsNotNull` specification.

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/InTheFuture.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/InTheFuture.java
@@ -30,11 +30,11 @@ import javax.persistence.criteria.Expression;
  *
  * <p>Supports date type fields.</p>
  */
-public class InTheFuture<T, TimeType extends Comparable<TimeType>> extends PathSpecification<T> {
+public class InTheFuture<T, TimeType extends Comparable<TimeType>> extends PathSpecification<T> implements ZeroArgSpecification {
 
 	private static final long serialVersionUID = 1L;
 
-	public InTheFuture(QueryContext queryContext, String path) {
+	public InTheFuture(QueryContext queryContext, String path, String[] args) {
 		super(queryContext, path);
 	}
 

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/InThePast.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/InThePast.java
@@ -29,11 +29,11 @@ import javax.persistence.criteria.Expression;
  *
  * <p>Supports date type fields.</p>
  */
-public class InThePast<T, TimeType extends Comparable<TimeType>> extends PathSpecification<T> {
+public class InThePast<T, TimeType extends Comparable<TimeType>> extends PathSpecification<T> implements ZeroArgSpecification {
 
 	private static final long serialVersionUID = 1L;
 
-	public InThePast(QueryContext queryContext, String path) {
+	public InThePast(QueryContext queryContext, String path, String[] args) {
 		super(queryContext, path);
 	}
 

--- a/src/test/java/net/kaczmarzyk/e2e/converter/LocalDateTimeE2eTest.java
+++ b/src/test/java/net/kaczmarzyk/e2e/converter/LocalDateTimeE2eTest.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -130,6 +131,22 @@ public class LocalDateTimeE2eTest extends E2eTestBase {
 
 			return customerRepo.findAll(spec);
 		}
+
+	    @ResponseBody
+	    @RequestMapping(value = "/customersWithSpecialOffer")
+	    public Object findByCustomersWithAvailableSpecialOffer(
+		    @Spec(path="dateOfNextSpecialOffer", spec=InTheFuture.class) Specification<Customer> spec) {
+
+		    return customerRepo.findAll(spec);
+	    }
+
+	    @ResponseBody
+	    @RequestMapping(value = "/customersWithExpiredSpecialOffer")
+	    public Object findByCustomersWithExpiredSpecialOffer(
+		    @Spec(path="dateOfNextSpecialOffer", spec=InThePast.class) Specification<Customer> spec) {
+
+		    return customerRepo.findAll(spec);
+	    }
     }
 
     @Test
@@ -283,5 +300,48 @@ public class LocalDateTimeE2eTest extends E2eTestBase {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.[?(@.firstName=='Marge')]").exists())
 				.andExpect(jsonPath("$[1]").doesNotExist());
+	}
+
+	@Test
+	public void findsByNextSpecialOfferFromFuture() throws Exception {
+		customer("Barry", "Benson")
+			.nextSpecialOffer(OffsetDateTime.now().plusDays(7))
+			.build(em);
+		customer("Vanessa", "Bloom")
+			.nextSpecialOffer(OffsetDateTime.now().minusDays(7))
+			.build(em);
+
+		mockMvc.perform(get("/customersWithSpecialOffer")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$").isArray())
+			.andExpect(jsonPath("$[0].firstName").value("Barry"))
+			.andExpect(jsonPath("$[0].lastName").value("Benson"))
+			.andExpect(jsonPath("$[1]").doesNotExist());
+	}
+
+	@Test
+	public void findsByNextSpecialOfferFromPast() throws Exception {
+		customer("Barry", "Benson")
+			.nextSpecialOffer(OffsetDateTime.now().plusDays(7))
+			.build(em);
+		customer("Vanessa", "Bloom")
+			.nextSpecialOffer(OffsetDateTime.now().minusDays(7))
+			.build(em);
+
+		mockMvc.perform(get("/customersWithExpiredSpecialOffer")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$").isArray())
+			.andExpect(jsonPath("$[0].firstName").value("Homer"))
+			.andExpect(jsonPath("$[1].firstName").value("Marge"))
+			.andExpect(jsonPath("$[2].firstName").value("Bart"))
+			.andExpect(jsonPath("$[3].firstName").value("Lisa"))
+			.andExpect(jsonPath("$[4].firstName").value("Maggie"))
+			.andExpect(jsonPath("$[5].firstName").value("Moe"))
+			.andExpect(jsonPath("$[6].firstName").value("Minnie"))
+			.andExpect(jsonPath("$[7].firstName").value("Ned"))
+			.andExpect(jsonPath("$[8].firstName").value("Vanessa"))
+			.andExpect(jsonPath("$[9]").doesNotExist());
 	}
 }

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/InTheFutureTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/InTheFutureTest.java
@@ -62,7 +62,7 @@ public class InTheFutureTest extends ComparableTestBase {
 
 	@Override
 	protected Specification<Customer> makeUUT(String path, String[] value, Converter converter) {
-		return new InTheFuture<>(queryCtx, path);
+		return new InTheFuture<>(queryCtx, path, new String[0]);
 	}
 
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/InThePastTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/InThePastTest.java
@@ -63,7 +63,7 @@ public class InThePastTest extends ComparableTestBase {
 
 	@Override
 	protected Specification<Customer> makeUUT(String path, String[] value, Converter converter) {
-		return new InThePast<>(queryCtx, path);
+		return new InThePast<>(queryCtx, path, new String[0]);
 	}
 
 	@Test


### PR DESCRIPTION
Changes introduced in `InTheFuture` and `InThePast` specifications:
* both specifications are now implementing `ZeroArgSpecification` interface
* extended constructors with new `String[] args` parameter (specification must contain at least 3-args constructor)