### PR TITLE
2.x json params handle non-json and GET requests gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v2.19.0
+=======
+* Json body parameters no longer throws when:
+  * Content-type is omitted
+  * Content-type is any other than application/json
+
 v2.18.1
 =======
 * Fixed a bug related to specifications that always returned all available values. Fixed specs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 Contributing guidelines
 =======================
 
-This docoument gathers important informations for potential contributors.
+This document gathers important information for potential contributors.
 
-Specification Argument Resolver is an open-source library intially written an maintained as a hobby projecy by a single developer. Since its inception (2014), several developers contributed by reporting issues and creating Pull Requests. This is much appreciated and very helpful. At the same time, even a working code and Pull Request requires review and additional testing by the original author. Following guidelines will make the process much easier and allow merging PRs faster.
+Specification Argument Resolver is an open-source library initially written and maintained as a hobby project by a single developer. Since its inception (2014), several developers contributed by reporting issues and creating Pull Requests. This is much appreciated and very helpful. At the same time, even a working code and Pull Request requires review and additional testing by the original author. Following guidelines will make the process much easier and allow merging PRs faster.
 
 1. Follow the formatting conventions (check the indentation and spacing of the preexisting files). This sounds like not a big deal, but code formatted in a different way is much harder to review.
 2. Don't change too much at once -- a coherent PR is easier to merge. If you change too many things in "architecture" or core concepts when impelementing a feature, then it will be very hard to review the PR.
 3. Add unit tests, please. This project has very decent code coverage. It contains multiple unit tests and integration tests (by integration test in this context I mean a test that starts up a Spring context and creates a test controllers etc.). If you don't add unit tests, then I will have to write them myself -- and this is fine, but it will prolong the merging process significantly (as this is still just a hobby project for me).
-4. Extend REAMDE if you add a new feature. This is crucial from the library user's perspective. If you don't extend the README, then I will have to do it myself -- and this is find, but it will prolong the merging process significantly (again -- this is just a hobby project for me, and I have (too) many other personal and profesional commitments).
+4. Extend README if you add a new feature. This is crucial from the library user's perspective. If you don't extend the README, then I will have to do it myself -- and this is fine, but it will prolong the merging process significantly (again -- this is just a hobby project for me, and I have (too) many other personal and professional commitments).
 
 Thank you very much for reading this! Thank you for all contributions. Open source for the win! 
 

--- a/README.md
+++ b/README.md
@@ -1114,6 +1114,8 @@ Request `POST /customers/find` with the following body is not valid (`JsonParseE
 }
 ```
 
+Json body parameters are optional in requests, and they can be omitted from the payload. To successfully resolve the parameters, requests must define a Content-type: application/json header and must have a JSON request body, otherwise the parameters will not be recognized and the criteria will not be applied. As most client implementations (e.g. fetch) do not allow GET or DELETE requests with body and Content-type, Json body parameters can be practically used only with POST, PUT and PATCH requests.
+
 Type conversions for HTTP parameters
 -------------------
 

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/WebRequestProcessingContext.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/WebRequestProcessingContext.java
@@ -107,12 +107,13 @@ public class WebRequestProcessingContext implements ProcessingContext {
 
 	private BodyParams getBodyParams() {
 		if (isNull(bodyParams)) {
+			this.bodyParams = BodyParams.empty();
 			String contentType = getRequestHeaderValue(CONTENT_TYPE);
-			MediaType mediaType = parseMediaType(contentType);
-			if (APPLICATION_JSON.includes(mediaType)) {
-				this.bodyParams = JsonBodyParams.parse(getRequestBody());
-			} else {
-				throw new IllegalArgumentException("Content-type not supported, content-type=" + contentType);
+			if (!isNull(contentType)){
+				MediaType mediaType = parseMediaType(contentType);
+				if (APPLICATION_JSON.includes(mediaType)) {
+					this.bodyParams = JsonBodyParams.parse(getRequestBody());
+				}
 			}
 		}
 		return bodyParams;

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/BodyParamsTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/BodyParamsTest.java
@@ -15,14 +15,23 @@
  */
 package net.kaczmarzyk.spring.data.jpa.utils;
 
+import org.junit.Test;
+
 import java.util.Collection;
-import java.util.Collections;
 
-public interface BodyParams {
+import static org.assertj.core.api.Assertions.assertThat;
 
-	Collection<String> getParamValues(String paramKey);
+public class BodyParamsTest {
 
-	static BodyParams empty() {
-		return paramKey -> Collections.emptyList();
+	@Test
+	public void emptyBodyParamsReturnsEmptyArray() {
+		//given
+		BodyParams emptyBodyParams = BodyParams.empty();
+
+		//when
+		Collection<String> value = emptyBodyParams.getParamValues("key");
+
+		//then
+		assertThat(value).isEmpty();
 	}
 }

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/JsonBodyParamsTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/JsonBodyParamsTest.java
@@ -16,21 +16,14 @@
 package net.kaczmarzyk.spring.data.jpa.utils;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
-import net.kaczmarzyk.utils.ReflectionUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
 
 public class JsonBodyParamsTest {
 

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/WebRequestProcessingContextTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/WebRequestProcessingContextTest.java
@@ -246,15 +246,28 @@ public class WebRequestProcessingContextTest {
 		assertThat(getPathVariableFromContext(context, "orderId")).isEqualTo("99");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void shouldThrowIllegalArgumentExceptionWhenContentTypeIsDifferentThanJson() {
+	@Test
+	public void resolvesEmptyBodyParamWhenContentTypeIsDifferentThanJson() {
 		NativeWebRequest req = mock(NativeWebRequest.class);
 
 		when(req.getHeader(CONTENT_TYPE)).thenReturn(MediaType.APPLICATION_PDF.toString());
 
 		WebRequestProcessingContext context = new WebRequestProcessingContext(null, req);
 
-		context.getBodyParamValues("example");
+		String[] bodyParamValues = context.getBodyParamValues("example");
+		assertThat(bodyParamValues).isEmpty();
+	}
+
+	@Test
+	public void resolvesEmptyBodyParamWhenContentTypeIsNotProvided() {
+		NativeWebRequest req = mock(NativeWebRequest.class);
+
+		when(req.getHeader(CONTENT_TYPE)).thenReturn(null);
+
+		WebRequestProcessingContext context = new WebRequestProcessingContext(null, req);
+
+		String[] bodyParamValues = context.getBodyParamValues("example");
+		assertThat(bodyParamValues).isEmpty();
 	}
 
 	@Test(expected = IllegalStateException.class)


### PR DESCRIPTION
Details described in #249 .

As this might be a breaking change for existing projects, I would propose to bump the minor version (2.19.0).

I am not sure how to include the change into 3.x also, can you please advise? Thanks.