### PR TITLE
Fix PMD version

### DIFF
--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -32,7 +32,7 @@ jobs:
           distribution: 'adopt'
       - name: Run PMD
         id: pmd
-        uses: pmd/pmd-github-action@967a81f8b657c87f7c3e96b62301cb1a48efef29
+        uses: pmd/pmd-github-action@v1.4.0
         with:
           rulesets: 'rulesets/java/quickstart.xml'
           sourcePath: 'src/main/java'


### PR DESCRIPTION
On a previous action run (https://github.com/tkaczmarzyk/specification-arg-resolver/actions/runs/4963928607), I got this error:

> Annotations
> 1 error and 1 warning
> pmd-code-scan
> Unable to locate executable file: /opt/hostedtoolcache/pmd/7.0.0-rc2/x64/pmd-bin-7.0.0-rc2/bin/run.sh. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
> pmd-code-scan
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: pmd/pmd-github-action@967a81f8b657c87f7c3e96b62301cb1a48efef29. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

I have very little experience with GH actions, but it seemed to me that bumping the PMD version might help, so I prepared this PR just in case it helps.