### PR TITLE
Minor code optimization for SpecificationFactory

### DIFF
--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
@@ -136,8 +136,8 @@ public class SpecificationFactory {
 	}
 
 	private void forEachSupportedInterfaceSpecificationDefinition(Class<?> target, Consumer<Annotation> specificationBuilder) {
-		for (Class<? extends Annotation> annotationType : resolversBySupportedType.keySet()) {
-			if (target.getAnnotations().length != 0) {
+		if (target.getAnnotations().length != 0) {
+			for (Class<? extends Annotation> annotationType : resolversBySupportedType.keySet()) {
 				Annotation potentialAnnotation = target.getAnnotation(annotationType);
 				if (potentialAnnotation != null) {
 					specificationBuilder.accept(potentialAnnotation);


### PR DESCRIPTION

Hi,
I stumbled upon this while debugging something in an application using your library. All possible annotation types would be checked for every target class from the interface tree. This made finding and analyzing a specific tree member (the only one with actual annotations) a bit tedious during debugging.

Thought I'd share this tiny improvement here :)