### PR TITLE
SAR-267 ignore case strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v3.2.0
+=======
+* **BREAKING CHANGE**: Fixed case-insensitive specifications (`EqualIgnoreCase`, `NotEqualIgnoreCase`, `LikeIgnoreCase`, `NotLikeIgnoreCase`, `StartingWithIgnoreCase`, `EndingWithIgnoreCase`) to use database `UPPER()` function for both sides of comparison
+  * This fixes incorrect query results when database and application use different locale settings or handle special characters differently (e.g., German ß character)
+  * Please see `Case Insensitive Support` section of README.md for more details.
+
 v3.1.1
 =======
 * Optimized distinct query evaluation in join

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/IgnoreCaseStrategy.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/IgnoreCaseStrategy.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.domain;
+
+/**
+ * Defines strategies for case-insensitive string comparisons in specifications.
+ */
+public enum IgnoreCaseStrategy {
+    
+    /**
+     * Uses database UPPER() function for both sides of comparison.
+     * This is the default strategy for compatibility with Spring Data JPA.
+     * Example SQL: WHERE UPPER(column) = UPPER(value)
+     * Strategy used by default.
+     */
+    DATABASE_UPPER,
+    
+    /**
+     * Uses database LOWER() function for both sides of comparison.
+     * May be preferable for certain locales (e.g., German with ß character).
+     * Example SQL: WHERE LOWER(column) = LOWER(value)
+     */
+    DATABASE_LOWER,
+    
+    /**
+     * Uses application-side case conversion.
+     * Warning: This strategy may lead to inconsistent results when the application
+     * and database use different case conversion rules (e.g., German ß character).
+     * 
+     * @deprecated Use {@link #DATABASE_UPPER} or {@link #DATABASE_LOWER} for consistent behavior.
+     *             This option is kept for backward compatibility only.
+     */
+    @Deprecated(since = "3.2", forRemoval = true)
+    APPLICATION
+}

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/IgnoreCaseStrategyAware.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/IgnoreCaseStrategyAware.java
@@ -15,25 +15,18 @@
  */
 package net.kaczmarzyk.spring.data.jpa.domain;
 
-import java.util.Locale;
-
 /**
- * <p>Specifications that implement this interface will be provided with Locale
- * after instantiation. Locale is important e.g. when {@code String.toUpperCase} is used
- * (typically in case-insensitive comparisons).</p> 
+ * <p>Specifications that implement this interface will be provided with IgnoreCaseStrategy
+ * after instantiation. This strategy determines how case-insensitive comparisons are performed.</p>
  * 
- * @deprecated Use {@link IgnoreCaseStrategy#DATABASE_UPPER} or {@link IgnoreCaseStrategy#DATABASE_LOWER}  instead of relying on application-side
- *             locale handling. This interface is kept for backward compatibility but will be removed in a future version.
- * 
- * @author Tomasz Kaczmarzyk
- * 
+ * @since 3.2
+ *
  * @see EqualIgnoreCase
  * @see NotEqualIgnoreCase
  * @see LikeIgnoreCase
  * @see NotLikeIgnoreCase
  */
-@Deprecated
-public interface LocaleAware {
+public interface IgnoreCaseStrategyAware {
 
-	void setLocale(Locale locale);
+	void setIgnoreCaseStrategy(IgnoreCaseStrategy ignoreCaseStrategy);
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/CaseConversionHelper.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/CaseConversionHelper.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.utils;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
+
+import java.util.Locale;
+
+/**
+ * Helper class for applying case conversion strategies in specifications.
+ * 
+ * @author Jakub Radlica
+ * @since 3.2
+ */
+public class CaseConversionHelper {
+    
+    /**
+     * Applies case conversion to both column expression and value according to the strategy.
+     */
+    @SuppressWarnings("deprecation")
+    public static ConvertedExpressions applyCaseConversion(
+            CriteriaBuilder cb,
+            Expression<String> columnExpression,
+            String value,
+            IgnoreCaseStrategy strategy,
+            Locale locale) {
+        
+        IgnoreCaseStrategy effectiveStrategy = strategy != null ? strategy : IgnoreCaseStrategy.DATABASE_UPPER;
+        
+        switch (effectiveStrategy) {
+            case DATABASE_UPPER:
+                return new ConvertedExpressions(
+                    cb.upper(columnExpression),
+                    cb.upper(cb.literal(value))
+                );
+                
+            case DATABASE_LOWER:
+                return new ConvertedExpressions(
+                    cb.lower(columnExpression),
+                    cb.lower(cb.literal(value))
+                );
+                
+            case APPLICATION:
+                Locale effectiveLocale = locale != null ? locale : Locale.getDefault();
+                String convertedValue = value.toUpperCase(effectiveLocale);
+                return new ConvertedExpressions(
+                    cb.upper(columnExpression),
+                    cb.literal(convertedValue)
+                );
+                
+            default:
+                throw new IllegalArgumentException("Unknown case strategy: " + effectiveStrategy);
+        }
+    }
+    
+    public record ConvertedExpressions(
+            Expression<String> column,
+            Expression<String> value
+    ) {
+        
+        /**
+         * Creates a new instance with the given expressions.
+         *
+         * @param column the column expression (must not be null)
+         * @param value the value expression (must not be null)
+         * @throws IllegalArgumentException if either expression is null
+         */
+        public ConvertedExpressions {
+            if (column == null) {
+                throw new IllegalArgumentException("Column expression must not be null");
+            }
+            if (value == null) {
+                throw new IllegalArgumentException("Value expression must not be null");
+            }
+        }
+    }
+}

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/SpecificationBuilder.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/SpecificationBuilder.java
@@ -15,6 +15,7 @@
  */
 package net.kaczmarzyk.spring.data.jpa.utils;
 
+import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
 import net.kaczmarzyk.spring.data.jpa.web.ProcessingContext;
 import net.kaczmarzyk.spring.data.jpa.web.SpecificationFactory;
 import net.kaczmarzyk.spring.data.jpa.web.StandaloneProcessingContext;
@@ -54,7 +55,8 @@ public final class SpecificationBuilder<T extends Specification> {
 	
 	private SpecificationBuilder(Class<T> specInterface, Locale defaultLocale) {
 		this.specInterface = specInterface;
-		this.specificationFactory = new SpecificationFactory(null, null, defaultLocale);
+		// Use DATABASE_UPPER as default strategy for standalone usage
+		this.specificationFactory = new SpecificationFactory(null, null, defaultLocale, IgnoreCaseStrategy.DATABASE_UPPER);
 	}
 
 	public static <T extends Specification<?>> SpecificationBuilder<T> specification(Class<T> specInterface) {

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationArgumentResolver.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationArgumentResolver.java
@@ -15,9 +15,7 @@
  */
 package net.kaczmarzyk.spring.data.jpa.web;
 
-import java.lang.annotation.Annotation;
-import java.util.Locale;
-
+import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.ConversionService;
@@ -27,6 +25,9 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import java.lang.annotation.Annotation;
+import java.util.Locale;
+
 
 /**
  * @author Tomasz Kaczmarzyk
@@ -34,38 +35,58 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  */
 public class SpecificationArgumentResolver implements HandlerMethodArgumentResolver {
 
+	private static final IgnoreCaseStrategy DEFAULT_IGNORE_CASE_STRATEGY = IgnoreCaseStrategy.DATABASE_UPPER;
+	
 	private SpecificationFactory specificationFactory;
 
 	public SpecificationArgumentResolver() {
-		 this(null, null, Locale.getDefault());
+		 this(null, null, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY);
 	}
 	
 	public SpecificationArgumentResolver(ConversionService conversionService) {
-		this(conversionService, null, Locale.getDefault());
+		this(conversionService, null, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY);
 	}
 	
 	public SpecificationArgumentResolver(ConversionService conversionService, Locale defaultLocale) {
-		this(conversionService, null, defaultLocale);
+		this(conversionService, null, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY);
 	}
 	
 	public SpecificationArgumentResolver(ConversionService conversionService, AbstractApplicationContext abstractApplicationContext) {
-		this(conversionService, abstractApplicationContext, Locale.getDefault());
+		this(conversionService, abstractApplicationContext, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY);
 	}
 	
 	public SpecificationArgumentResolver(Locale defaultLocale) {
-		this(null, null, defaultLocale);
+		this(null, null, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY);
 	}
 	
 	public SpecificationArgumentResolver(AbstractApplicationContext applicationContext) {
-		this(null, applicationContext);
+		this(null, applicationContext, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY);
 	}
 	
 	public SpecificationArgumentResolver(AbstractApplicationContext applicationContext, Locale defaultLocale) {
-		this(null, applicationContext, defaultLocale);
+		this(null, applicationContext, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY);
 	}
-	
+
 	public SpecificationArgumentResolver(ConversionService conversionService, AbstractApplicationContext abstractApplicationContext, Locale defaultLocale) {
-		this.specificationFactory = new SpecificationFactory(conversionService, abstractApplicationContext, defaultLocale);
+		this(conversionService, abstractApplicationContext, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY);
+	}
+
+	public SpecificationArgumentResolver(IgnoreCaseStrategy ignoreCaseStrategy) {
+		this(null, null, Locale.getDefault(), ignoreCaseStrategy);
+	}
+
+	public SpecificationArgumentResolver(ConversionService conversionService, IgnoreCaseStrategy ignoreCaseStrategy) {
+		this(conversionService, null, Locale.getDefault(), ignoreCaseStrategy);
+	}
+
+	public SpecificationArgumentResolver(AbstractApplicationContext applicationContext, IgnoreCaseStrategy ignoreCaseStrategy) {
+		this(null, applicationContext, Locale.getDefault(), ignoreCaseStrategy);
+	}
+
+	public SpecificationArgumentResolver(ConversionService conversionService, AbstractApplicationContext abstractApplicationContext,
+	                                     Locale defaultLocale, IgnoreCaseStrategy ignoreCaseStrategy) {
+		IgnoreCaseStrategy effectiveStrategy = ignoreCaseStrategy != null ? ignoreCaseStrategy : DEFAULT_IGNORE_CASE_STRATEGY;
+		this.specificationFactory = new SpecificationFactory(conversionService, abstractApplicationContext, defaultLocale, effectiveStrategy);
 	}
 	
 

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
@@ -15,6 +15,7 @@
  */
 package net.kaczmarzyk.spring.data.jpa.web;
 
+import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
 import net.kaczmarzyk.spring.data.jpa.utils.TypeUtil;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.core.convert.ConversionService;
@@ -36,8 +37,21 @@ public class SpecificationFactory {
 
 	private Map<Class<? extends Annotation>, SpecificationResolver<? extends Annotation>> resolversBySupportedType;
 
-	public SpecificationFactory(ConversionService conversionService, AbstractApplicationContext abstractApplicationContext, Locale locale) {
-		SimpleSpecificationResolver simpleSpecificationResolver = new SimpleSpecificationResolver(conversionService, abstractApplicationContext, locale);
+	public SpecificationFactory(
+			ConversionService conversionService,
+			AbstractApplicationContext abstractApplicationContext,
+			Locale defaultLocale,
+			IgnoreCaseStrategy defaultIgnoreCaseStrategy
+	) {
+		if (defaultIgnoreCaseStrategy == null) {
+			throw new IllegalArgumentException("IgnoreCaseStrategy must not be null");
+		}
+		SimpleSpecificationResolver simpleSpecificationResolver = new SimpleSpecificationResolver(
+				conversionService,
+				abstractApplicationContext,
+				defaultLocale,
+				defaultIgnoreCaseStrategy
+		);
 
 		resolversBySupportedType = Arrays.asList(
 						simpleSpecificationResolver,
@@ -97,7 +111,7 @@ public class SpecificationFactory {
 	}
 
 	private void resolveSpecFromInterfaceAnnotations(ProcessingContext context,
-													 List<Specification<Object>> accumulator) {
+	                                                 List<Specification<Object>> accumulator) {
 		Collection<Class<?>> ifaceTree = TypeUtil.interfaceTree(context.getParameterType());
 
 		for (Class<?> iface : ifaceTree) {

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWithIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWithIgnoreCaseTest.java
@@ -49,12 +49,10 @@ public class EndingWithIgnoreCaseTest extends IntegrationTestBase {
 	@Test
 	public void filtersByFirstLevelProperty() {
 		EndingWithIgnoreCase<Customer> lastNameSimpson = new EndingWithIgnoreCase<>(queryCtx, "lastName", "SIMPSON");
-		lastNameSimpson.setLocale(Locale.getDefault());
 		List<Customer> result = customerRepo.findAll(lastNameSimpson);
 		assertThat(result).hasSize(2).containsOnly(homerSimpson, margeSimpson);
 
 		EndingWithIgnoreCase<Customer> firstNameWithO = new EndingWithIgnoreCase<>(queryCtx, "firstName", "ER");
-		firstNameWithO.setLocale(Locale.getDefault());
 		result = customerRepo.findAll(firstNameWithO);
 		assertThat(result).hasSize(1).containsOnly(homerSimpson);
 	}
@@ -63,13 +61,11 @@ public class EndingWithIgnoreCaseTest extends IntegrationTestBase {
 	public void filtersByNestedProperty() {
 		EndingWithIgnoreCase<Customer> streetWithEvergreen = new EndingWithIgnoreCase<>(queryCtx, "address.street",
 				"TERRACE");
-		streetWithEvergreen.setLocale(Locale.getDefault());
 		List<Customer> result = customerRepo.findAll(streetWithEvergreen);
 		assertThat(result).hasSize(2).containsOnly(homerSimpson, margeSimpson);
 
 		EndingWithIgnoreCase<Customer> streetWithSpaceEvergreen = new EndingWithIgnoreCase<>(queryCtx, "address.street",
 				"EVERGREEN");
-		streetWithSpaceEvergreen.setLocale(Locale.getDefault());
 		result = customerRepo.findAll(streetWithSpaceEvergreen);
 		assertThat(result).hasSize(0);
 	}

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EqualIgnoreCaseLocaleIntegrationTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EqualIgnoreCaseLocaleIntegrationTest.java
@@ -19,7 +19,7 @@ import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Locale;
+
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,20 +44,11 @@ public class EqualIgnoreCaseLocaleIntegrationTest extends IntegrationTestBase {
 		homerWithTurkishCapitalI = customer("Homer", "SİMPSON").build(em);
 	}
 
-	@Test
-	public void usesLocaleWhenPerformingComparisons() {
-		EqualIgnoreCase<Customer> simpsons = new EqualIgnoreCase<>(queryCtx, "lastName", new String[] { "simpson" }, defaultConverter);
-		
-		// English locale
-		simpsons.setLocale(Locale.ENGLISH);
-		List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
+	    @Test
+    public void filtersIgnoringCaseAccordingToDbCollation() {
+        EqualIgnoreCase<Customer> simpsons = new EqualIgnoreCase<>(queryCtx, "lastName", new String[] { "simpson" }, defaultConverter);
+        List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
 
-		assertThat(simpsonsFound).hasSize(2).containsOnly(homerWithLowercaseI, homerWithEnglishCapitalI);
-		
-		// Turkish locale
-		simpsons.setLocale(new Locale("tr", "TR"));
-		simpsonsFound = customerRepo.findAll(simpsons);
-
-		assertThat(simpsonsFound).hasSize(1).containsOnly(homerWithTurkishCapitalI); // homerWithLowercaseI is not included as test db does not use Turkish collation
-	}
+        assertThat(simpsonsFound).hasSize(2).containsOnly(homerWithLowercaseI, homerWithEnglishCapitalI);
+    }
 }

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/GermanAndTurkishCharactersTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/GermanAndTurkishCharactersTest.java
@@ -1,0 +1,318 @@
+/**
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.domain;
+
+import net.kaczmarzyk.spring.data.jpa.Customer;
+import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jakub Radlica
+ */
+public class GermanAndTurkishCharactersTest extends IntegrationTestBase {
+	
+	// German test data
+	private Customer juergenWeiss;      // Contains ß (eszett)
+	private Customer melissaMueller;    // Contains ü (umlaut)
+	private Customer hansSchmidt;       // Regular ASCII for comparison
+	
+	// Turkish test data
+	private Customer istanbulUser;      // İstanbul with uppercase İ (with dot)
+	private Customer ibrahimLowerCase; // ibrahim with lowercase i
+	private Customer ibrahimUpperCase; // İBRAHİM with uppercase İ (with dot)
+	private Customer englishIan;        // Ian with regular ASCII I
+	
+	@BeforeEach
+	public void initData() {
+		// German customers
+		juergenWeiss = customer("Jürgen", "Weiß").build(em);
+		melissaMueller = customer("Melissa", "Müller").build(em);
+		hansSchmidt = customer("Hans", "Schmidt").build(em);
+		
+		// Turkish customers
+		istanbulUser = customer("İstanbul", "User").build(em);
+		ibrahimLowerCase = customer("ibrahim", "istanbul").build(em);
+		ibrahimUpperCase = customer("İBRAHİM", "İSTANBUL").build(em);
+		englishIan = customer("Ian", "Smith").build(em);
+	}
+	
+	@Nested
+	@DisplayName("German characters (ß, ü)")
+	class GermanCharacter {
+		
+		@Nested
+		class IgnoreCaseStrategyApplication {
+			
+			@Test
+			@DisplayName("H2 still converts ß→SS even with COLLATION=EN")
+			public void h2ConvertsEszettDespiteCollation() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "lastName", "ß");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.APPLICATION);
+				query.setLocale(Locale.GERMAN);
+				
+				//when: Java converts ß to SS, H2 also converts despite COLLATION=EN
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then: H2 finds the record (but MySQL/PostgreSQL wouldn't!)
+				assertThat(result)
+						.as("H2 ignores COLLATION=EN and still converts ß→SS. " +
+						    "In MySQL/PostgreSQL this would return empty!")
+						.containsExactly(juergenWeiss);
+				// NOTE: This test documents H2-specific behavior.
+				// With MySQL/PostgreSQL default collation, this would be .isEmpty()
+			}
+			
+			@Test
+			public void findsByUmlaut() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "lastName", "müller");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.APPLICATION);
+				query.setLocale(Locale.GERMAN);
+				
+				//when:
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.containsExactly(melissaMueller); // 'müller'.toUpperCase() = 'MÜLLER'
+			}
+		}
+		
+		@Nested
+		class IgnoreCaseStrategyDatabaseUpper {
+			
+			@Test
+			public void findsByEszett() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "lastName", "ß");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.containsExactly(juergenWeiss);
+			}
+			
+			@Test
+			public void findsByUmlaut() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "lastName", "MÜLLER");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.containsExactly(melissaMueller);
+			}
+		}
+		
+		@Nested
+		class IgnoreCaseStrategyDatabaseLower {
+			
+			@Test
+			public void findsByEszett() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "lastName", "WEIß");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_LOWER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.containsExactly(juergenWeiss);
+			}
+			
+			@Test
+			public void findsByUmlaut() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "lastName", "Üller");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_LOWER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.containsExactly(melissaMueller);
+			}
+		}
+	}
+	
+	@Nested
+	@DisplayName("Turkish characters (İ/i distinction)")
+	class TurkishCharacter {
+		
+		@Nested
+		class IgnoreCaseStrategyApplication {
+			
+			@Test
+			public void findsByITurkishCapital() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "firstName", "i");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.APPLICATION);
+				query.setLocale(new Locale("tr", "TR"));
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.contains(istanbulUser, ibrahimUpperCase)
+						.doesNotContain(englishIan, ibrahimLowerCase);
+			}
+			
+			@Test
+			public void findsByTurkishMixedCase() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "firstName", "İstanbul");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.APPLICATION);
+				query.setLocale(new Locale("tr", "TR"));
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.as("Database lowercase conversion for Turkish characters")
+						.containsExactly(istanbulUser);
+			}
+			
+			@Test
+			public void findsByNonTurkish() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "firstName", "I");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.APPLICATION);
+				query.setLocale(new Locale("tr", "TR"));
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.containsExactlyInAnyOrder(englishIan, melissaMueller, ibrahimLowerCase);
+			}
+		}
+		
+		@Nested
+		class IgnoreCaseStrategyDatabaseUpper {
+			
+			@Test
+			public void findsByTurkishUppercase() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "firstName", "İBRAHİM");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.contains(ibrahimUpperCase);
+			}
+			
+			@Test
+			public void findsByTurkishMixedCase() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "firstName", "İstanbul");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.as("Database lowercase conversion for Turkish characters")
+						.containsExactly(istanbulUser);
+			}
+			
+			@Test
+			public void findsByNonTurkish() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "firstName", "I");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.containsExactlyInAnyOrder(englishIan, melissaMueller, ibrahimLowerCase);
+			}
+		}
+		
+		@Nested
+		class IgnoreCaseStrategyDatabaseLower {
+			
+			@Test
+			public void findsByTurkishUppercase() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "firstName", "İBRAHİM");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_LOWER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.contains(ibrahimUpperCase);
+			}
+			
+			@Test
+			public void findsByTurkishMixedCase() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "firstName", "İstanbul");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_LOWER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.as("Database lowercase conversion for Turkish characters")
+						.containsExactly(istanbulUser);
+			}
+			
+			@Test
+			public void findsByNonTurkish() {
+				//given
+				LikeIgnoreCase<Customer> query = new LikeIgnoreCase<>(queryCtx, "firstName", "I");
+				query.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_LOWER);
+				
+				//when
+				List<Customer> result = customerRepo.findAll(query);
+				
+				//then
+				assertThat(result)
+						.containsExactlyInAnyOrder(englishIan, melissaMueller, istanbulUser, ibrahimLowerCase, ibrahimUpperCase);
+			}
+		}
+	}
+}

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/LikeIgnoreCaseLocaleIntegrationTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/LikeIgnoreCaseLocaleIntegrationTest.java
@@ -47,21 +47,41 @@ public class LikeIgnoreCaseLocaleIntegrationTest extends IntegrationTestBase {
 	}
 
 	@Test
-	public void usesLocaleWhenPerformingComparisons() {
-		
-		// English locale
-		LikeIgnoreCase<Customer> simpsons = new LikeIgnoreCase<>(queryCtx, "lastName", new String[] { "i" });
-		simpsons.setLocale(Locale.ENGLISH);
+	public void filtersIgnoringCaseAccordingToDbCollation() {
+		LikeIgnoreCase<Customer> simpsons = new LikeIgnoreCase<>(queryCtx, "lastName", new String[]{"i"});
+		simpsons.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
 		List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
 
 		assertThat(simpsonsFound).hasSize(2).containsOnly(homerWithLowercaseI, homerWithEnglishCapitalI);
+	}
+	
+	@Test
+	public void filtersIgnoringCaseAccordingToDbCollation_turkishCapitalI() {
+		LikeIgnoreCase<Customer> simpsons = new LikeIgnoreCase<>(queryCtx, "lastName", new String[]{"İ"});
+		simpsons.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
+		List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
 		
-		// Turkish locale
-		simpsons = new LikeIgnoreCase<>(queryCtx, "lastName", new String[] { "i" });
+		assertThat(simpsonsFound).hasSize(1).containsOnly(homerWithTurkishCapitalI);
+	}
+	
+	@Test
+	public void filtersIgnoringCaseWithDatabaseLowerStrategy_turkishCapitalI() {
+		LikeIgnoreCase<Customer> simpsons = new LikeIgnoreCase<>(queryCtx, "lastName", new String[] { "İ" });
+		simpsons.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_LOWER);
 		simpsons.setLocale(new Locale("tr", "TR"));
-		simpsonsFound = customerRepo.findAll(simpsons);
+		List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
+		
+		assertThat(simpsonsFound).hasSize(1).containsOnly(homerWithTurkishCapitalI);
+	}
+	
+	@Test
+	public void filtersIgnoringCaseWithApplicationStrategy_turkishCapitalI() {
+		LikeIgnoreCase<Customer> simpsons = new LikeIgnoreCase<>(queryCtx, "lastName", new String[] { "İ" });
+		simpsons.setIgnoreCaseStrategy(IgnoreCaseStrategy.APPLICATION);
+		simpsons.setLocale(new Locale("tr", "TR"));
+		List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
 
-		assertThat(simpsonsFound).hasSize(1).containsOnly(homerWithTurkishCapitalI); // homerWithLowercaseI is not included because test db does not use Turkish collation
+		assertThat(simpsonsFound).hasSize(1).containsOnly(homerWithTurkishCapitalI);
 	}
 }
 

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/LikeIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/LikeIgnoreCaseTest.java
@@ -51,14 +51,12 @@ public class LikeIgnoreCaseTest extends IntegrationTestBase {
     @Test
     public void filtersFirstLevelPropertyIgnoringCase() {
         LikeIgnoreCase<Customer> lastNameSimpson = new LikeIgnoreCase<>(queryCtx, "lastName", "sIMPSOn");
-        lastNameSimpson.setLocale(Locale.getDefault());
         List<Customer> result = customerRepo.findAll(lastNameSimpson);
         assertThat(result)
             .hasSize(2)
             .containsOnly(homerSimpson, margeSimpson);
         
         LikeIgnoreCase<Customer> firstNameWithO = new LikeIgnoreCase<>(queryCtx, "firstName", "o");
-        firstNameWithO.setLocale(Locale.getDefault());
         result = customerRepo.findAll(firstNameWithO);
         assertThat(result)
             .hasSize(2)
@@ -68,7 +66,6 @@ public class LikeIgnoreCaseTest extends IntegrationTestBase {
     @Test
     public void filtersByNestedPropertyIgnoringCase() {
         LikeIgnoreCase<Customer> streetWithEvergreen = new LikeIgnoreCase<>(queryCtx, "address.street", "EvErGReeN");
-        streetWithEvergreen.setLocale(Locale.getDefault());
         List<Customer> result = customerRepo.findAll(streetWithEvergreen);
         assertThat(result).hasSize(2).containsOnly(homerSimpson, margeSimpson);
     }

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotEqualIgnoreCaseLocaleIntegrationTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotEqualIgnoreCaseLocaleIntegrationTest.java
@@ -19,7 +19,7 @@ import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Locale;
+
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,21 +45,11 @@ public class NotEqualIgnoreCaseLocaleIntegrationTest extends IntegrationTestBase
 	}
 
 	@Test
-	public void usesLocaleWhenPerformingComparisons() {
-		
-		// English locale
-		NotEqualIgnoreCase<Customer> simpsons = new NotEqualIgnoreCase<>(queryCtx, "lastName", new String[] { "simpson" }, defaultConverter);
-		simpsons.setLocale(Locale.ENGLISH);
-		List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
+    public void filtersIgnoringCaseAccordingToDbCollation() {
+        NotEqualIgnoreCase<Customer> simpsons = new NotEqualIgnoreCase<>(queryCtx, "lastName", new String[] { "simpson" }, defaultConverter);
+        List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
 
-		assertThat(simpsonsFound).hasSize(1).containsOnly(homerWithTurkishCapitalI);
-		
-		// Turkish locale
-		simpsons = new NotEqualIgnoreCase<>(queryCtx, "lastName", new String[] { "simpson" }, defaultConverter);
-		simpsons.setLocale(new Locale("tr", "TR"));
-		simpsonsFound = customerRepo.findAll(simpsons);
-
-		assertThat(simpsonsFound).hasSize(2).containsOnly(homerWithLowercaseI, homerWithEnglishCapitalI); // lowercase i is included as well because test db collation is not Turkish
-	}
+        assertThat(simpsonsFound).hasSize(1).containsOnly(homerWithTurkishCapitalI);
+    }
 
 }

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotEqualIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotEqualIgnoreCaseTest.java
@@ -114,7 +114,6 @@ public class NotEqualIgnoreCaseTest extends NotEqualTest {
 
 	private <T> NotEqualIgnoreCase<T> notEqualIgnoreCaseSpec(String path, Object expectedValue) {
 		NotEqualIgnoreCase<T> spec = new NotEqualIgnoreCase<>(queryCtx, path, new String[]{expectedValue.toString()}, defaultConverter);
-		spec.setLocale(Locale.getDefault());
 		return spec;
 	}
 

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeIgnoreCaseLocaleIntegrationTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeIgnoreCaseLocaleIntegrationTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Locale;
+
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,24 +40,12 @@ public class NotLikeIgnoreCaseLocaleIntegrationTest extends IntegrationTestBase 
     }
 
     @Test
-    public void usesLocaleWhenPerformingComparisons() {
-
-        // English locale
+    public void filtersIgnoringCaseAccordingToDbCollation() {
         NotLikeIgnoreCase<Customer> simpsons = new NotLikeIgnoreCase<>(queryCtx, "lastName", new String[] { "i" });
-        simpsons.setLocale(Locale.ENGLISH);
         List<Customer> simpsonsFound = customerRepo.findAll(simpsons);
 
         assertThat(simpsonsFound)
                 .hasSize(1)
                 .containsOnly(homerWithTurkishCapitalI);
-
-        // Turkish locale
-        simpsons = new NotLikeIgnoreCase<>(queryCtx, "lastName", new String[] { "i" });
-        simpsons.setLocale(new Locale("tr", "TR"));
-        simpsonsFound = customerRepo.findAll(simpsons);
-
-        assertThat(simpsonsFound)
-                .hasSize(2)
-                .containsOnly(homerWithLowercaseI, homerWithEnglishCapitalI); // homerWithLowercaseI is included because test db does not use Turkish collation
     }
 }

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeIgnoreCaseTest.java
@@ -46,14 +46,12 @@ public class NotLikeIgnoreCaseTest extends IntegrationTestBase {
     @Test
     public void filtersFirstLevelPropertyIgnoringCase() {
         NotLikeIgnoreCase<Customer> lastNameSimpson = new NotLikeIgnoreCase<>(queryCtx, "lastName", "sIMPSOn");
-        lastNameSimpson.setLocale(Locale.getDefault());
         List<Customer> result = customerRepo.findAll(lastNameSimpson);
         assertThat(result)
                 .hasSize(1)
                 .containsOnly(moeSzyslak);
 
         NotLikeIgnoreCase<Customer> firstNameWithO = new NotLikeIgnoreCase<>(queryCtx, "firstName", "o");
-        firstNameWithO.setLocale(Locale.getDefault());
         result = customerRepo.findAll(firstNameWithO);
         assertThat(result)
                 .hasSize(1)
@@ -63,7 +61,6 @@ public class NotLikeIgnoreCaseTest extends IntegrationTestBase {
     @Test
     public void filtersByNestedPropertyIgnoringCase() {
         NotLikeIgnoreCase<Customer> streetWithEvergreen = new NotLikeIgnoreCase<>(queryCtx, "address.street", "EvErGReeN");
-        streetWithEvergreen.setLocale(Locale.getDefault());
         List<Customer> result = customerRepo.findAll(streetWithEvergreen);
         assertThat(result)
                 .hasSize(1)

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/StartingWithIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/StartingWithIgnoreCaseTest.java
@@ -52,12 +52,10 @@ public class StartingWithIgnoreCaseTest extends IntegrationTestBase {
 	public void filtersByFirstLevelProperty() {
 		StartingWithIgnoreCase<Customer> lastNameSimpson = new StartingWithIgnoreCase<>(queryCtx, "lastName",
 				"SIMPSON");
-		lastNameSimpson.setLocale(Locale.getDefault());
 		List<Customer> result = customerRepo.findAll(lastNameSimpson);
 		assertThat(result).hasSize(2).containsOnly(homerSimpson, margeSimpson);
 
 		StartingWithIgnoreCase<Customer> firstNameWithO = new StartingWithIgnoreCase<>(queryCtx, "firstName", "HO");
-		firstNameWithO.setLocale(Locale.getDefault());
 		result = customerRepo.findAll(firstNameWithO);
 		assertThat(result).hasSize(1).containsOnly(homerSimpson);
 	}
@@ -66,13 +64,11 @@ public class StartingWithIgnoreCaseTest extends IntegrationTestBase {
 	public void filtersByNestedProperty() {
 		StartingWithIgnoreCase<Customer> streetWithEvergreen = new StartingWithIgnoreCase<>(queryCtx, "address.street",
 				"EVERGREEN");
-		streetWithEvergreen.setLocale(Locale.getDefault());
 		List<Customer> result = customerRepo.findAll(streetWithEvergreen);
 		assertThat(result).hasSize(2).containsOnly(homerSimpson, margeSimpson);
 
 		StartingWithIgnoreCase<Customer> streetWithTerrace = new StartingWithIgnoreCase<>(queryCtx, "address.street",
 				"TERRACE");
-		streetWithTerrace.setLocale(Locale.getDefault());
 		result = customerRepo.findAll(streetWithTerrace);
 		assertThat(result).hasSize(0);
 	}

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedSpecInterfaceWithComplexInheritanceTreeTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedSpecInterfaceWithComplexInheritanceTreeTest.java
@@ -276,13 +276,13 @@ public class AnnotatedSpecInterfaceWithComplexInheritanceTreeTest extends Annota
 
 	private NotEqualIgnoreCase<Object> newNotEqualIgnoreCase(QueryContext queryContext, String path, String[] args, Converter converter) {
 		NotEqualIgnoreCase<Object> spec = new NotEqualIgnoreCase<>(queryContext, path, args, converter);
-		spec.setLocale(Locale.getDefault());
+		spec.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
 		return spec;
 	}
 
 	private EqualIgnoreCase<Object> newEqualIgnoreCase(QueryContext queryContext, String path, String[] args, Converter converter) {
 		EqualIgnoreCase<Object> spec = new EqualIgnoreCase<>(queryContext, path, args, converter);
-		spec.setLocale(Locale.getDefault());
+		spec.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
 		return spec;
 	}
 

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedSpecInterfaceWithComplexInheritanceTreeTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/AnnotatedSpecInterfaceWithComplexInheritanceTreeTest.java
@@ -277,12 +277,14 @@ public class AnnotatedSpecInterfaceWithComplexInheritanceTreeTest extends Annota
 	private NotEqualIgnoreCase<Object> newNotEqualIgnoreCase(QueryContext queryContext, String path, String[] args, Converter converter) {
 		NotEqualIgnoreCase<Object> spec = new NotEqualIgnoreCase<>(queryContext, path, args, converter);
 		spec.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
+		spec.setLocale(Locale.getDefault());
 		return spec;
 	}
 
 	private EqualIgnoreCase<Object> newEqualIgnoreCase(QueryContext queryContext, String path, String[] args, Converter converter) {
 		EqualIgnoreCase<Object> spec = new EqualIgnoreCase<>(queryContext, path, args, converter);
 		spec.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
+		spec.setLocale(Locale.getDefault());
 		return spec;
 	}
 

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverConstValueSpELSupportIntegrationTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverConstValueSpELSupportIntegrationTest.java
@@ -18,6 +18,7 @@ package net.kaczmarzyk.spring.data.jpa.web;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBaseWithSARConfiguredWithApplicationContext;
 import net.kaczmarzyk.spring.data.jpa.domain.EmptyResultOnTypeMismatch;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
+import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
 import net.kaczmarzyk.spring.data.jpa.utils.Converter;
 import net.kaczmarzyk.spring.data.jpa.utils.ThrowableAssertions;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
@@ -49,7 +50,7 @@ public class SimpleSpecificationResolverConstValueSpELSupportIntegrationTest ext
 	
 	@BeforeEach
 	public void initializeResolver() {
-		this.resolver = new SimpleSpecificationResolver(null, abstractApplicationContext, Locale.getDefault());
+		this.resolver = new SimpleSpecificationResolver(null, abstractApplicationContext, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER);
 	}
 	
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverDefaultValueIntegrationTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverDefaultValueIntegrationTest.java
@@ -18,6 +18,7 @@ package net.kaczmarzyk.spring.data.jpa.web;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBaseWithSARConfiguredWithApplicationContext;
 import net.kaczmarzyk.spring.data.jpa.domain.EmptyResultOnTypeMismatch;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
+import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
 import net.kaczmarzyk.spring.data.jpa.utils.Converter;
 import net.kaczmarzyk.spring.data.jpa.utils.ThrowableAssertions;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
@@ -49,7 +50,7 @@ public class SimpleSpecificationResolverDefaultValueIntegrationTest extends Inte
 	
 	@BeforeEach
 	public void initializeResolver() {
-		this.resolver = new SimpleSpecificationResolver(null, abstractApplicationContext, Locale.getDefault());
+		this.resolver = new SimpleSpecificationResolver(null, abstractApplicationContext, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER);
 	}
 	
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverTest.java
@@ -26,6 +26,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.web.context.request.NativeWebRequest;
 
+
 import java.util.Locale;
 
 import static net.kaczmarzyk.spring.data.jpa.web.annotation.OnTypeMismatch.EXCEPTION;
@@ -282,57 +283,7 @@ public class SimpleSpecificationResolverTest extends ResolverTestBase {
         		.isInstanceOf(IllegalStateException.class);
     }
 
-    @Test
-    public void passesDefaultSystemLocaleToLocaleAwareSpecification() {
-    	MethodParameter param = MethodParameter.forExecutable(testMethod("testMethodWithLocaleAwareSpec"), 0);
-        NativeWebRequest req = mock(NativeWebRequest.class);
-
-        when(req.getParameterValues("theParameter")).thenReturn(new String[] {"i"});
-
-        WebRequestProcessingContext ctx = new WebRequestProcessingContext(param, req);
-
-        Specification<Object> builtSpec = resolver.buildSpecification(ctx, param.getParameterAnnotation(Spec.class));
-
-        Locale localePassedToSpec = ReflectionUtils.getFromPath(builtSpec, "wrappedSpec.locale");
-
-        assertThat(localePassedToSpec).isEqualTo(Locale.getDefault());
-    }
-
-    @Test
-    public void passesGlobalCustomLocaleToLocaleAwareSpecification() {
-    	ReflectionUtils.set(resolver, "defaultLocale", new Locale("tr", "TR"));
-
-    	MethodParameter param = MethodParameter.forExecutable(testMethod("testMethodWithLocaleAwareSpec"), 0);
-        NativeWebRequest req = mock(NativeWebRequest.class);
-
-        when(req.getParameterValues("theParameter")).thenReturn(new String[] {"i"});
-
-        WebRequestProcessingContext ctx = new WebRequestProcessingContext(param, req);
-
-        Specification<Object> builtSpec = resolver.buildSpecification(ctx, param.getParameterAnnotation(Spec.class));
-
-        Locale localePassedToSpec = ReflectionUtils.getFromPath(builtSpec, "wrappedSpec.locale");
-
-        assertThat(localePassedToSpec).isEqualTo(new Locale("tr", "TR"));
-    }
-
-    @Test
-    public void usesCustomLocaleSetInSpecConfigAndPassesItToLocaleAwareSpecification() {
-    	ReflectionUtils.set(resolver, "defaultLocale", new Locale("pl", "PL")); // global custom locale that is going to be overriden by @Spec.config
-
-    	MethodParameter param = MethodParameter.forExecutable(testMethod("testMethodWithLocaleAwareSpecAndCustomLocaleConfig"), 0);
-        NativeWebRequest req = mock(NativeWebRequest.class);
-
-        when(req.getParameterValues("theParameter")).thenReturn(new String[] {"i"});
-
-        WebRequestProcessingContext ctx = new WebRequestProcessingContext(param, req);
-
-        Specification<Object> builtSpec = resolver.buildSpecification(ctx, param.getParameterAnnotation(Spec.class));
-
-        Locale localePassedToSpec = ReflectionUtils.getFromPath(builtSpec, "wrappedSpec.locale");
-
-        assertThat(localePassedToSpec).isEqualTo(new Locale("tr", "TR"));
-    }
+    
 
     public static class TestController {
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,3 +3,7 @@ SpEL-support.lastName.value=Szyslak
 SpEL-support.constVal.value=Property val
 SpEL-support.defaultVal.value=defaultPropertyVal
 SpEL-support.paramName=parameterLoadedFromSpel
+
+# H2 Configuration to simulate MySQL behavior
+# MODE=MYSQL makes H2 behave more like MYSQL
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;COLLATION=EN;


### PR DESCRIPTION
Issue: https://github.com/tkaczmarzyk/specification-arg-resolver/issues/267

- Fixed case-insensitive specifications (EqualIgnoreCase, LikeIgnoreCase, etc.) to use database UPPER() function on both sides of comparison, resolving incorrect query results when database and application use different locale settings or handle special characters differently (e.g., German ß, Turkish İ/i)
- Introduced configurable IgnoreCaseStrategy with three options: DATABASE_UPPER (default), DATABASE_LOWER, and APPLICATION (deprecated)