### PR TITLE
fix: include extended interfaces in springdoc parameters

### DIFF
--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/swagger/springdoc/SpecificationArgResolverSpringdocOperationCustomizer.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/swagger/springdoc/SpecificationArgResolverSpringdocOperationCustomizer.java
@@ -112,17 +112,24 @@ public class SpecificationArgResolverSpringdocOperationCustomizer implements Ope
 	}
 
 	private List<Annotation> extractAnnotationsFromMethodParameter(MethodParameter methodParameter) {
-
 		List<Annotation> annotations = new ArrayList<>(
 			asList(methodParameter.getParameterAnnotations()));
 
-		if (methodParameter.getParameterType() != Specification.class) {
-			List<Annotation> innerParameterAnnotations = asList(methodParameter.getParameterType().getAnnotations());
-			annotations.addAll(innerParameterAnnotations);
-		}
+    extractAnnotationsRecursive(annotations, methodParameter.getParameterType());
 
 		return annotations;
 	}
+
+  private void extractAnnotationsRecursive(List<Annotation> buffer, Class<?> clazz) {
+    if (clazz != Specification.class) {
+      List<Annotation> innerParameterAnnotations = asList(clazz.getAnnotations());
+      buffer.addAll(innerParameterAnnotations);
+
+      for (Class<?> extendedInterface : clazz.getInterfaces()) {
+        extractAnnotationsRecursive(buffer, extendedInterface);
+      }
+    }
+  }
 
 	private List<Parameter> createParametersFromSpecs(List<Spec> specs, List<String> requiredParams, List<String> requiredHeaders) {
 		List<Parameter> parameters = specs.stream()

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/swagger/springdoc/SpecificationArgResolverSpringdocOperationCustomizerTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/swagger/springdoc/SpecificationArgResolverSpringdocOperationCustomizerTest.java
@@ -282,6 +282,31 @@ public class SpecificationArgResolverSpringdocOperationCustomizerTest {
 	}
 
 	@Test
+	public void shouldCorrectlyReadParametersFromExtendedCustomFilterWithAnnotations() throws NoSuchMethodException {
+		// given
+		HandlerMethod handlerMethod = handlerMethodForControllerMethodAndParameterType("customExtendedFilterWithAnnotationsTestMethod", ExtendedTestFilterWithAnnotations.class);
+		Operation operation = new Operation();
+
+		// when
+		Operation customizedOperation = springdocOperationCustomizer.customize(operation, handlerMethod);
+
+		// then
+		assertThatOperation(customizedOperation)
+			.hasParametersCount(4)
+			.containsParameterAtIndex(0)
+			.withQueryParameterName("annotatedFilterThirdParam")
+			.and()
+			.containsParameterAtIndex(1)
+			.withQueryParameterName("annotatedFilterFourthParam")
+      .and()
+			.containsParameterAtIndex(2)
+      .withQueryParameterName("annotatedFilterFirstParam")
+      .and()
+      .containsParameterAtIndex(3)
+      .withQueryParameterName("annotatedFilterSecondParam");
+	}
+
+	@Test
 	public void shouldCorrectlyReadParametersFromCustomFilterWithoutAnnotations() throws NoSuchMethodException {
 		// given
 		HandlerMethod handlerMethod = handlerMethodForControllerMethodAndParameterType("customFilterWithoutAnnotationsTestMethod", TestFilterWithoutAnnotations.class);
@@ -489,6 +514,11 @@ public class SpecificationArgResolverSpringdocOperationCustomizerTest {
 
 		}
 
+		@RequestMapping(value = "/custom-extended-filter-with-annotations")
+		public void customExtendedFilterWithAnnotationsTestMethod(ExtendedTestFilterWithAnnotations filter) {
+
+		}
+
 		@RequestMapping(value = "/custom-filter-without-annotations")
 		public void customFilterWithoutAnnotationsTestMethod(
 			@Or({
@@ -560,8 +590,15 @@ public class SpecificationArgResolverSpringdocOperationCustomizerTest {
 
 	}
 
-	private interface TestFilterWithoutAnnotations extends Specification<Object> {
+	@Or({
+		@Spec(path = "", params = "annotatedFilterThirdParam", spec = Like.class),
+		@Spec(path = "", params = "annotatedFilterFourthParam", spec = Like.class),
+	})
+	private interface ExtendedTestFilterWithAnnotations extends TestFilterWithAnnotations {
 
 	}
 
+	private interface TestFilterWithoutAnnotations extends Specification<Object> {
+
+	}
 }


### PR DESCRIPTION
Fixes missing springdoc annotations for extended interfaces.

```java
@Spec(path = "", params = "foo", spec = Like.class),
private interface Foo extends Specification<Object> {}

@Spec(path = "", params = "bar", spec = Like.class),
private interface Bar extends Foo {}
 
@RequestMapping
public void endpoint(Bar filter) {}
```

The above snippet would previously only show the `bar` parameter in the generated OpenApi specification. This PR makes sure that both `bar` and `foo` are included.