### PR TITLE
Introduce character escaping support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v3.4.0
+======
+* Added character escaping support for `LIKE`-based specifications. It allows to treat special characters (such as `%` and `_`) as literals during database searches - developed by @Nawrok 🚀
+  * Escaping can be configured globally via `SpecificationArgumentResolver` or locally for each `@Spec` definition via `config` attribute.
+  * Please see `Character escaping support` section of [README.md](README.md) for more details.
+
 v3.3.0
 ======
 * added `InIgnoreCase` and `NotInIgnoreCase` - developed by @cschierle 🚀

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can also take a look on working Spring Boot apps that use this library:
    * [Type conversions for HTTP parameters](#type-conversions-for-http-parameters) -- information about supported type conversions (i.e. ability to convert HTTP parameters into Java types such as `LocalDateTime`, etc.) and the support of defining custom converters
    * [Case insensitivity support](#case-insensitive-support) -- information about case-insensitive strategies used for case-insensitive specifications 
    * [Locale support](#locale-support) -- information about `Locale` configuration for case-insensitive matching 
+   * [Character escaping support](#character-escaping-support) -- information about escaping special characters in LIKE-based specifications
    * [SpEL support](#spel-support) -- information about Spring Expression Language support
    * [Swagger support](#swagger-support) -- information about support for generation of swagger documentation
    * [Building specifications outside the web layer](#building-specifications-outside-the-web-layer)
@@ -130,7 +131,9 @@ Usage: `@Spec(path="firstName", spec=Like.class)`.
 
 There are also other variants which apply the wildcard only on the beginning or the ending of the provided value: `StartingWith` and `EndingWith`.
 
-The negated version is available: `NotLike` which executes queries such as `(..) where firstName not like %Homer%`
+The negated version is available: `NotLike` which executes queries such as `(..) where firstName not like %Homer%`.
+
+All `Like`-based specifications support [character escaping](#character-escaping-support).
 
 ### LikeIgnoreCase  ###
 
@@ -143,6 +146,8 @@ There are also other variants which apply the wildcard only on the beginning or 
 Case-insensitive comparisons are performed using the database's `UPPER()` function on both sides of the comparison. The results depend on your database's collation settings. Locale settings is important for case-insensitive searches. Please check the [Locale support](#locale-support) section for details.
 
 A negation for this specification is also available: `NotLikeIgnoreCase`.
+
+All `Like`-based specifications support [character escaping](#character-escaping-support).
 
 ### Equal ###
 
@@ -1303,6 +1308,52 @@ You can also configure it for each individual specfication definition via `@Spec
 
 Locale config is used for enum conversions (if enum contains local characters) and for case-insentivie specification if `APPLICATION` [case insensitive strategy](#case-insensitive-support) is used
 
+Character escaping support
+--------------
+### In version v3.4.0+
+Specification-arg-resolver allows escaping special characters (such as `%` and `_`) in `LIKE`-based specifications. This ensures that these characters are treated as literals rather than wildcards during database searches.
+
+**By default, character escaping is disabled** (`CharEscaper.DISABLED)`) to maintain the existing behavior.
+
+You can configure the character escaper globally when registering the argument resolver:
+```java
+@Override
+public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+    // Using backslash as escape char and escaping % and _
+    argumentResolvers.add(new SpecificationArgumentResolver(new CharEscaper('\\', Set.of('%', '_'))));
+}
+```
+
+> **Note:** The library does not provide any preconfigured `CharEscaper` instances due to the diversity of escaping mechanisms across different database systems. For instance:
+> *   In **PostgreSQL**, the default escape character for `LIKE` patterns is a backslash `\` (see [PostgreSQL Documentation](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE)).
+> *   In **Microsoft SQL Server**, while it supports the `ESCAPE` clause, it often uses bracket-based syntax (e.g., `[%]`) for literal matching (see [MSSQL Documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql)).
+>
+> Therefore, it is the user's responsibility to configure the `CharEscaper` appropriately based on the specific database driver and dialect used in their project.
+
+You can also configure escaping for each individual specification definition via `@Spec.config`. The configuration value is a single string where:
+*   The **first character** of the string is the **escape character** (e.g., `\`).
+*   All **subsequent characters** are the **characters to be escaped** (e.g., `%` and `_`).
+
+For standard `LIKE` specifications:
+```java
+// config = "escapeChar" + "charsToEscape..."
+@Spec(path = "name", spec = Like.class, config = "\\%_")
+```
+
+For specifications that are also `LocaleAware` (e.g., `LikeIgnoreCase`), the library supports a multi-slot `config` array to maintain **backward compatibility**. In this case:
+*   The **first element** (`config[0]`) is used for the **Locale**.
+*   The **second element** (`config[1]`) is used for the **escaping configuration**.
+
+```java
+@Spec(path = "name", spec = LikeIgnoreCase.class, config = {"pl_PL", "\\%_"})
+```
+
+To explicitly disable escaping for a specific definition even if a global default is present, use an empty string as the configuration value:
+```java
+@Spec(path = "name", spec = Like.class, config = "")
+```
+
+The character escaping is supported by `Like`, `StartingWith`, `EndingWith`, `NotLike` and their `IgnoreCase` variants.
 
 SpEL support
 ------------

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/CharEscapeAware.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/CharEscapeAware.java
@@ -16,25 +16,20 @@
 package net.kaczmarzyk.spring.data.jpa.domain;
 
 import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
-import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 
 /**
- * parameter bound with appended %: {@code args[0] + "%"}
- * 
- * @author Matt S.Y. Ho
+ * Interface to be implemented by specifications that support character escaping.
  *
- * @param <T>
+ * @since 3.4
+ * @author Sebastian Nawrocki
  */
-public class StartingWithIgnoreCase<T> extends LikeIgnoreCase<T> {
+public interface CharEscapeAware {
 
-	private static final long serialVersionUID = 1L;
+    /**
+     * Applies the provided {@link CharEscaper} to the specification.
+     *
+     * @param charEscaper the escaper to be used
+     */
+    void applyCharEscaper(CharEscaper charEscaper);
 
-	public StartingWithIgnoreCase(QueryContext queryCtx, String path, String... args) {
-		super(queryCtx, path, args);
-	}
-
-	@Override
-	protected String resolvePattern(String argument, CharEscaper charEscaper) {
-		return charEscaper.escape(argument) + "%";
-	}
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWith.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWith.java
@@ -15,6 +15,7 @@
  */
 package net.kaczmarzyk.spring.data.jpa.domain;
 
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 
 /**
@@ -30,6 +31,10 @@ public class EndingWith<T> extends Like<T> {
 
 	public EndingWith(QueryContext queryContext, String path, String... args) {
 		super(queryContext, path, args);
-		this.pattern = "%" + args[0];
+	}
+
+	@Override
+	protected String resolvePattern(String argument, CharEscaper charEscaper) {
+		return "%" + charEscaper.escape(argument);
 	}
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWithIgnoreCase.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWithIgnoreCase.java
@@ -15,6 +15,7 @@
  */
 package net.kaczmarzyk.spring.data.jpa.domain;
 
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 
 /**
@@ -30,6 +31,10 @@ public class EndingWithIgnoreCase<T> extends LikeIgnoreCase<T> {
 
 	public EndingWithIgnoreCase(QueryContext queryCtx, String path, String... args) {
 		super(queryCtx, path, args);
-		this.pattern = "%" + args[0];
+	}
+
+	@Override
+	protected String resolvePattern(String argument, CharEscaper charEscaper) {
+		return "%" + charEscaper.escape(argument);
 	}
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/Like.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/Like.java
@@ -15,45 +15,58 @@
  */
 package net.kaczmarzyk.spring.data.jpa.domain;
 
+import jakarta.persistence.criteria.*;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
+import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
+
 import java.util.Arrays;
 import java.util.Objects;
-
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
-
-import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 
 /**
  * Filters with {@code path like %pattern%} where-clause.
  * 
  * @author Tomasz Kaczmarzyk
  */
-public class Like<T> extends PathSpecification<T> implements WithoutTypeConversion {
+public class Like<T> extends PathSpecification<T> implements WithoutTypeConversion, CharEscapeAware {
 
 	private static final long serialVersionUID = 1L;
-	
-	protected String pattern;
+
+    protected String argument;
+    protected Character escapeChar;
+    protected String pattern;
 
     public Like(QueryContext queryContext, String path, String... args) {
         super(queryContext, path);
         if (args == null || args.length != 1) {
             throw new IllegalArgumentException("Expected exactly one argument (the fragment to match against), but got: " + Arrays.toString(args));
         } else {
-            this.pattern = "%" + args[0] + "%";
+            this.argument = args[0];
+            applyCharEscaper(CharEscaper.DISABLED);
         }
+    }
+
+    protected String resolvePattern(String argument, CharEscaper charEscaper) {
+        return "%" + charEscaper.escape(argument) + "%";
+    }
+
+    @Override
+    public void applyCharEscaper(CharEscaper charEscaper) {
+        this.escapeChar = charEscaper.getEscapeChar();
+        this.pattern = resolvePattern(argument, charEscaper);
     }
 
     @Override
     public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
-        return builder.like(this.<String>path(root), pattern);
+        Expression<Character> escapeLiteral = escapeChar != null ? builder.literal(escapeChar) : null;
+        return builder.like(this.<String>path(root), pattern, escapeLiteral);
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
+        result = prime * result + ((argument == null) ? 0 : argument.hashCode());
+        result = prime * result + ((escapeChar == null) ? 0 : escapeChar.hashCode());
         result = prime * result + ((pattern == null) ? 0 : pattern.hashCode());
         return result;
     }
@@ -70,13 +83,17 @@ public class Like<T> extends PathSpecification<T> implements WithoutTypeConversi
             return false;
         }
         Like<?> like = (Like<?>) o;
-        return Objects.equals(pattern, like.pattern);
+        return Objects.equals(argument, like.argument)
+                && Objects.equals(escapeChar, like.escapeChar)
+                && Objects.equals(pattern, like.pattern);
     }
 
     @Override
     public String toString() {
         return "Like[" +
-                "pattern='" + pattern + '\'' +
+                "argument='" + argument + '\'' +
+                ", escapeChar='" + escapeChar + '\'' +
+                ", pattern='" + pattern + '\'' +
                 ", path='" + path + '\'' +
                 ']';
     }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/LikeIgnoreCase.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/LikeIgnoreCase.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 
 /**
  * Filters with {@code path like %pattern%} where-clause and ignores pattern case
- * 
+ *
  * @author Michal Jankowski, Hazecod
  * @author Tomasz Kaczmarzyk
  *
@@ -31,30 +31,32 @@ import java.util.Locale;
 public class LikeIgnoreCase<T> extends Like<T> implements IgnoreCaseStrategyAware, LocaleAware {
 
 	private static final long serialVersionUID = 1L;
-	private IgnoreCaseStrategy ignoreCaseStrategy;
-	private Locale locale;
+
+	protected IgnoreCaseStrategy ignoreCaseStrategy;
+	protected Locale locale;
 
 	public LikeIgnoreCase(QueryContext queryCtx, String path, String... args) {
         super(queryCtx, path, args);
     }
-	
+
     @Override
     public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
         var converted = CaseConversionHelper.applyCaseConversion(
-            builder, 
-            this.<String>path(root), 
-            pattern, 
+            builder,
+            this.<String>path(root),
+            pattern,
             ignoreCaseStrategy,
             locale
         );
-        return builder.like(converted.column(), converted.value());
+		Expression<Character> escapeLiteral = escapeChar != null ? builder.literal(escapeChar) : null;
+        return builder.like(converted.column(), converted.value(), escapeLiteral);
     }
-    
+
     @Override
     public void setIgnoreCaseStrategy(IgnoreCaseStrategy ignoreCaseStrategy) {
         this.ignoreCaseStrategy = ignoreCaseStrategy;
     }
-    
+
     @Override
     @Deprecated
     public void setLocale(Locale locale) {
@@ -97,6 +99,13 @@ public class LikeIgnoreCase<T> extends Like<T> implements IgnoreCaseStrategyAwar
 
 	@Override
 	public String toString() {
-		return "LikeIgnoreCase [pattern=" + pattern + ", path=" + path + ", ignoreCaseStrategy=" + ignoreCaseStrategy + ", locale=" + locale + "]";
+		return "LikeIgnoreCase[" +
+				"argument='" + argument + '\'' +
+				", escapeChar='" + escapeChar + '\'' +
+				", pattern='" + pattern + '\'' +
+				", path='" + path + '\'' +
+				", ignoreCaseStrategy=" + ignoreCaseStrategy +
+				", locale=" + locale +
+				']';
 	}
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/NotLike.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/NotLike.java
@@ -15,14 +15,10 @@
  */
 package net.kaczmarzyk.spring.data.jpa.domain;
 
-import java.util.Arrays;
-import java.util.Objects;
-
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
-
 import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 
 /**
@@ -32,53 +28,26 @@ import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
  * 
  * @author Tomasz Kaczmarzyk
  */
-public class NotLike<T> extends PathSpecification<T> implements WithoutTypeConversion {
+public class NotLike<T> extends Like<T> {
 	
 	private static final long serialVersionUID = 1L;
-	
-	protected String pattern;
 
-    public NotLike(QueryContext queryContext, String path, String... args) {
-        super(queryContext, path);
-        if (args == null || args.length != 1) {
-            throw new IllegalArgumentException("Expected exactly one argument (the fragment to match against), but got: " + Arrays.toString(args));
-        } else {
-            this.pattern = "%" + args[0] + "%";
-        }
-    }
-
-    @Override
-    public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
-        return builder.not(builder.like(this.<String>path(root), pattern));
-    }
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = super.hashCode();
-		result = prime * result + ((pattern == null) ? 0 : pattern.hashCode());
-		return result;
+	public NotLike(QueryContext queryContext, String path, String... args) {
+		super(queryContext, path, args);
 	}
 
 	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-		if (!super.equals(o)) {
-			return false;
-		}
-		NotLike<?> notLike = (NotLike<?>) o;
-		return Objects.equals(pattern, notLike.pattern);
+	public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+		Predicate likePredicate = super.toPredicate(root, query, builder);
+		return builder.not(likePredicate);
 	}
 
 	@Override
 	public String toString() {
 		return "NotLike[" +
-				"pattern='" + pattern + '\'' +
+				"argument='" + argument + '\'' +
+				", escapeChar='" + escapeChar + '\'' +
+				", pattern='" + pattern + '\'' +
 				", path='" + path + '\'' +
 				']';
 	}

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeIgnoreCase.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeIgnoreCase.java
@@ -15,15 +15,11 @@
  */
 package net.kaczmarzyk.spring.data.jpa.domain;
 
-import net.kaczmarzyk.spring.data.jpa.utils.CaseConversionHelper;
-import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
-
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
-import java.util.Locale;
+import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 
 /**
  * Filters with {@code path not like %pattern%} where-clause and ignores pattern case
@@ -31,11 +27,9 @@ import java.util.Locale;
  * @author Kacper Leśniak (Tratif sp. z o.o.)
  *
  */
-public class NotLikeIgnoreCase<T> extends NotLike<T> implements IgnoreCaseStrategyAware, LocaleAware {
+public class NotLikeIgnoreCase<T> extends LikeIgnoreCase<T> {
 
     private static final long serialVersionUID = 1L;
-    private IgnoreCaseStrategy ignoreCaseStrategy;
-    private Locale locale;
 
     public NotLikeIgnoreCase(QueryContext queryContext, String path, String... args) {
         super(queryContext, path, args);
@@ -43,63 +37,19 @@ public class NotLikeIgnoreCase<T> extends NotLike<T> implements IgnoreCaseStrate
 
     @Override
     public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
-        var converted = CaseConversionHelper.applyCaseConversion(
-            builder,
-            this.<String>path(root),
-            pattern,
-            ignoreCaseStrategy,
-            locale
-        );
-        return builder.not(builder.like(converted.column(), converted.value()));
-    }
-    
-    @Override
-    public void setIgnoreCaseStrategy(IgnoreCaseStrategy ignoreCaseStrategy) {
-        this.ignoreCaseStrategy = ignoreCaseStrategy;
-    }
-    
-    @Override
-    @Deprecated
-    public void setLocale(Locale locale) {
-        this.locale = locale;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((ignoreCaseStrategy == null) ? 0 : ignoreCaseStrategy.hashCode());
-        result = prime * result + ((locale == null) ? 0 : locale.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        NotLikeIgnoreCase<?> other = (NotLikeIgnoreCase<?>) obj;
-        if (ignoreCaseStrategy != other.ignoreCaseStrategy) {
-            return false;
-        }
-        if (locale == null) {
-            if (other.locale != null) {
-                return false;
-            }
-        } else if (!locale.equals(other.locale)) {
-            return false;
-        }
-        return true;
+        Predicate likeIgnoreCase = super.toPredicate(root, query, builder);
+        return builder.not(likeIgnoreCase);
     }
 
     @Override
     public String toString() {
-        return "NotLikeIgnoreCase [pattern=" + pattern + ", path=" + path + ", ignoreCaseStrategy=" + ignoreCaseStrategy + ", locale=" + locale + "]";
+        return "NotLikeIgnoreCase[" +
+                "argument='" + argument + '\'' +
+                ", escapeChar='" + escapeChar + '\'' +
+                ", pattern='" + pattern + '\'' +
+                ", path='" + path + '\'' +
+                ", ignoreCaseStrategy=" + ignoreCaseStrategy +
+                ", locale=" + locale +
+                ']';
     }
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/StartingWith.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/domain/StartingWith.java
@@ -15,6 +15,7 @@
  */
 package net.kaczmarzyk.spring.data.jpa.domain;
 
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 
 /**
@@ -30,6 +31,10 @@ public class StartingWith<T> extends Like<T> {
 
 	public StartingWith(QueryContext queryCtx, String path, String... args) {
 		super(queryCtx, path, args);
-		this.pattern = args[0] + "%";
+	}
+
+	@Override
+	protected String resolvePattern(String argument, CharEscaper charEscaper) {
+		return charEscaper.escape(argument) + "%";
 	}
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/CharEscaper.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/CharEscaper.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2014-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.utils;
+
+import java.util.*;
+
+/**
+ * Component responsible for escaping special characters.
+ *
+ * @since 3.4
+ * @author Sebastian Nawrocki
+ */
+public class CharEscaper {
+
+    public static final CharEscaper DISABLED = new CharEscaper(null, Set.of());
+
+    private final Character escapeChar;
+    private final Set<Character> charsToEscape;
+
+    public CharEscaper(Character escapeChar, Collection<Character> charsToEscape) {
+        this.escapeChar = escapeChar;
+        this.charsToEscape = Set.copyOf(charsToEscape);
+    }
+
+    /**
+     * Performs escaping of the provided value using the configured escape character
+     * and characters to be escaped.
+     *
+     * @param value raw value to be escaped
+     * @return escaped value, or null if the input was null
+     */
+    public String escape(String value) {
+        if (escapeChar == null || value == null) {
+            return value;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (char c : value.toCharArray()) {
+            if (c == escapeChar || charsToEscape.contains(c)) {
+                sb.append(escapeChar);
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    public Character getEscapeChar() {
+        return escapeChar;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CharEscaper that = (CharEscaper) o;
+        return Objects.equals(escapeChar, that.escapeChar) && Objects.equals(charsToEscape, that.charsToEscape);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(escapeChar, charsToEscape);
+    }
+
+    @Override
+    public String toString() {
+        return "CharEscaper[" +
+                "escapeChar='" + escapeChar + '\'' +
+                ", charsToEscape=" + charsToEscape +
+                ']';
+    }
+}

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/ReflectionUtils.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/ReflectionUtils.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2014-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.utils;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Utility class for reflective operations.
+ *
+ * @since 3.4
+ * @author Sebastian Nawrocki
+ */
+public abstract class ReflectionUtils {
+
+    /**
+     * Attempts to execute a series of reflective operations sequentially.
+     * The first operation that completes without a {@link NoSuchMethodException} returns its result.
+     *
+     * @param <T> the type of the result
+     * @param operations the operations to be attempted
+     * @return the result of the first successful operation, or null if all threw {@link NoSuchMethodException}
+     * @throws Exception if any operation throws an exception other than {@link NoSuchMethodException}
+     */
+    @SafeVarargs
+    public static <T> T tryInstance(Callable<T>... operations) throws Exception {
+        for (Callable<T> operation : operations) {
+            try {
+                return operation.call();
+            } catch (NoSuchMethodException e) {
+                // ignore and try next
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/SpecificationBuilder.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/utils/SpecificationBuilder.java
@@ -50,13 +50,13 @@ public final class SpecificationBuilder<T extends Specification> {
 	private Map<String, String[]> bodyParams = new HashMap<>();
 
 	private SpecificationBuilder(Class<T> specInterface) {
-		this(specInterface, Locale.getDefault());
+		this(specInterface, Locale.getDefault(), CharEscaper.DISABLED);
 	}
 	
-	private SpecificationBuilder(Class<T> specInterface, Locale defaultLocale) {
+	private SpecificationBuilder(Class<T> specInterface, Locale defaultLocale, CharEscaper charEscaper) {
 		this.specInterface = specInterface;
 		// Use DATABASE_UPPER as default strategy for standalone usage
-		this.specificationFactory = new SpecificationFactory(null, null, defaultLocale, IgnoreCaseStrategy.DATABASE_UPPER);
+		this.specificationFactory = new SpecificationFactory(null, null, defaultLocale, IgnoreCaseStrategy.DATABASE_UPPER, charEscaper);
 	}
 
 	public static <T extends Specification<?>> SpecificationBuilder<T> specification(Class<T> specInterface) {

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolver.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolver.java
@@ -16,8 +16,10 @@
 package net.kaczmarzyk.spring.data.jpa.web;
 
 import net.kaczmarzyk.spring.data.jpa.domain.*;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import net.kaczmarzyk.spring.data.jpa.utils.Converter;
 import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
+import net.kaczmarzyk.spring.data.jpa.utils.ReflectionUtils;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -29,11 +31,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.expression.ParseException;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Locale;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -45,28 +43,34 @@ import static java.util.stream.Collectors.toList;
  * @author Jakub Radlica
  */
 class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
-	
+
 	private final ConversionService conversionService;
 	private final EmbeddedValueResolver embeddedValueResolver;
 	private final Locale defaultLocale;
 	private final IgnoreCaseStrategy defaultIgnoreCaseStrategy;
-	
-	public SimpleSpecificationResolver(ConversionService conversionService, AbstractApplicationContext applicationContext, Locale defaultLocale, IgnoreCaseStrategy ignoreCaseStrategy) {
+	private final CharEscaper defaultCharEscaper;
+
+	public SimpleSpecificationResolver(ConversionService conversionService,
+									   AbstractApplicationContext applicationContext,
+									   Locale defaultLocale,
+									   IgnoreCaseStrategy ignoreCaseStrategy,
+									   CharEscaper charEscaper) {
 		this.conversionService = conversionService;
 		this.embeddedValueResolver = applicationContext != null ? new EmbeddedValueResolver(applicationContext.getBeanFactory()) : null;
 		this.defaultLocale = defaultLocale;
 		this.defaultIgnoreCaseStrategy = ignoreCaseStrategy;
+		this.defaultCharEscaper = charEscaper;
 	}
-	
+
 	public SimpleSpecificationResolver() {
-		this(null, null, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER);
+		this(null, null, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER, CharEscaper.DISABLED);
 	}
-	
+
 	@Override
 	public Class<? extends Annotation> getSupportedSpecificationDefinition() {
 		return Spec.class;
 	}
-	
+
 	public Specification<Object> buildSpecification(ProcessingContext context, Spec def) {
 		try {
 			Collection<String> args = resolveSpecArguments(context, def);
@@ -78,67 +82,65 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 				return def.onTypeMismatch().wrap(spec);
 			}
 		} catch (NoSuchMethodException e) {
-			throw new IllegalStateException("Does the specification class expose at least one of the supported constructors?\n"
-					+ "It can be either:\n"
-					+ "  3-arg (QueryContext queryCtx, String path, String[] args)\n"
-					+ "  4-arg (QueryContext queryCtx, String path, String[] args, Converter converter)\n"
-					+ "  5-arg (QueryContext queryCtx, String path, String[] args, Converter converter, String[] config)", e);
+			throw new IllegalStateException("""
+					Does the specification class [%s] expose at least one of the supported constructors?
+					Supported signatures are:
+					  - (QueryContext queryCtx, String path, String[] args, Converter converter, String[] config)
+					  - (QueryContext queryCtx, String path, String[] args, Converter converter)
+					  - (QueryContext queryCtx, String path, String[] args)
+					  - (String path, String[] args, String[] config) [Legacy]""".formatted(def.spec().getName()), e);
 		} catch (RuntimeException e) {
 			throw e;
 		} catch (Exception e) {
 			throw new IllegalStateException(e);
 		}
 	}
-	
+
 	private boolean isZeroArgSpec(Spec def) {
 		return ZeroArgSpecification.class.isAssignableFrom(def.spec());
 	}
-	
+
 	@SuppressWarnings("unchecked")
-	private Specification<Object> newSpecification(Spec def, String[] argsArray, ProcessingContext context) throws InstantiationException, IllegalAccessException,
-			InvocationTargetException, NoSuchMethodException {
-		
+	private Specification<Object> newSpecification(Spec def, String[] argsArray, ProcessingContext context) throws Exception {
+
 		QueryContext queryCtx = context.queryContext();
 		Converter converter = resolveConverter(def);
-		
-		Specification<Object> spec;
-		if (def.config().length == 0) {
-			try {
-				spec = def.spec().getConstructor(QueryContext.class, String.class, String[].class)
-						.newInstance(queryCtx, def.path(), argsArray);
-			} catch (NoSuchMethodException e2) {
-				spec = def.spec().getConstructor(QueryContext.class, String.class, String[].class, Converter.class)
-						.newInstance(queryCtx, def.path(), argsArray, converter);
-			}
-		} else {
-			try {
-				spec = def.spec().getConstructor(QueryContext.class, String.class, String[].class, Converter.class, String[].class)
-						.newInstance(queryCtx, def.path(), argsArray, converter, def.config());
-			} catch (NoSuchMethodException e) {
-				try {
-					spec = def.spec().getConstructor(QueryContext.class, String.class, String[].class, Converter.class)
-							.newInstance(queryCtx, def.path(), argsArray, converter);
-				} catch (NoSuchMethodException e2) {
-					// legacy constructor support, to retain backward-compatibility
-					spec = def.spec().getConstructor(String.class, String[].class, String[].class)
-							.newInstance(def.path(), argsArray, def.config());
-				}
-			}
+
+		Specification<Object> spec = ReflectionUtils.tryInstance(
+				() -> def.spec().getConstructor(QueryContext.class, String.class, String[].class, Converter.class, String[].class)
+						.newInstance(queryCtx, def.path(), argsArray, converter, def.config()),
+				() -> def.spec().getConstructor(QueryContext.class, String.class, String[].class, Converter.class)
+						.newInstance(queryCtx, def.path(), argsArray, converter),
+				() -> def.spec().getConstructor(QueryContext.class, String.class, String[].class)
+						.newInstance(queryCtx, def.path(), argsArray),
+				// legacy constructor support, to retain backward-compatibility
+				() -> def.spec().getConstructor(String.class, String[].class, String[].class)
+						.newInstance(def.path(), argsArray, def.config())
+		);
+
+		if (spec == null) {
+			// if none of the constructors match
+			throw new NoSuchMethodException();
 		}
-		
+
 		if (spec instanceof IgnoreCaseStrategyAware && defaultIgnoreCaseStrategy != null) {
 			((IgnoreCaseStrategyAware) spec).setIgnoreCaseStrategy(defaultIgnoreCaseStrategy);
 		}
-		
+
 		// Set Locale for backward compatibility
 		if (spec instanceof LocaleAware) {
 			Locale targetLocale = determineLocale(def);
 			((LocaleAware) spec).setLocale(targetLocale);
 		}
-		
+
+		if (spec instanceof CharEscapeAware) {
+			CharEscaper charEscaper = determineCharEscaper(def, spec);
+			((CharEscapeAware) spec).applyCharEscaper(charEscaper);
+		}
+
 		return spec;
 	}
-	
+
 	private Locale determineLocale(Spec def) {
 		if (def.config().length == 0) {
 			return defaultLocale;
@@ -146,25 +148,47 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 			return LocaleUtils.toLocale(def.config()[0]);
 		}
 	}
-	
-	private Converter resolveConverter(Spec def) {
-		if (def.config().length == 0) {
-			return Converter.withTypeMismatchBehaviour(def.onTypeMismatch(), conversionService, defaultLocale);
+
+	private CharEscaper determineCharEscaper(Spec def, Specification<Object> spec) {
+		int configIndex = (spec instanceof LocaleAware) ? 1 : 0;
+		if (def.config().length <= configIndex) {
+			return defaultCharEscaper;
 		}
-		if (def.config().length == 1) {
-			if (LocaleAware.class.isAssignableFrom(def.spec())) { // if specification is locale-aware, then we assume that config contains locale
+
+		String configValue = def.config()[configIndex];
+		if (configValue == null) {
+			return defaultCharEscaper;
+		}
+		if (configValue.isEmpty()) {
+			return CharEscaper.DISABLED;
+		}
+
+		char escapeChar = configValue.charAt(0);
+		Set<Character> charsToEscape = new HashSet<>();
+		for (int i = 1; i < configValue.length(); i++) {
+			charsToEscape.add(configValue.charAt(i));
+		}
+		return new CharEscaper(escapeChar, charsToEscape);
+	}
+
+	private Converter resolveConverter(Spec def) {
+		if (def.config().length > 0) {
+			// if locale-aware we assume that first element of config contains locale
+			if (LocaleAware.class.isAssignableFrom(def.spec())) {
 				String localeConfig = def.config()[0];
 				Locale customlocale = LocaleUtils.toLocale(localeConfig);
 				return Converter.withTypeMismatchBehaviour(def.onTypeMismatch(), conversionService, customlocale);
-			} else { // otherwise we assume that config contains date format
+			}
+
+			// if not char-escape-aware we assume that first element of config contains date format
+			if (!CharEscapeAware.class.isAssignableFrom(def.spec())) {
 				String dateFormat = def.config()[0];
 				return Converter.withDateFormat(dateFormat, def.onTypeMismatch(), conversionService);
 			}
 		}
-		throw new IllegalStateException("config should contain only one value -- a date format"); // TODO support other config values as well
+		return Converter.withTypeMismatchBehaviour(def.onTypeMismatch(), conversionService, defaultLocale);
 	}
-	
-	
+
 	private Collection<String> resolveSpecArguments(ProcessingContext context, Spec specDef) {
 		if (specDef.constVal().length != 0) {
 			return resolveConstVal(specDef);
@@ -178,7 +202,7 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 			return resolveDefaultVal(context, specDef);
 		}
 	}
-	
+
 	private Collection<String> resolveConstVal(Spec specDef) {
 		if (embeddedValueResolver != null && specDef.valueInSpEL()) {
 			ArrayList<String> evaluatedArgs = new ArrayList<>(specDef.constVal().length);
@@ -190,7 +214,7 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 			return asList(specDef.constVal());
 		}
 	}
-	
+
 	private Collection<String> resolveDefaultVal(ProcessingContext context, Spec specDef) {
 		Collection<String> resolved = resolveSpecArgumentsFromHttpParameters(context, specDef);
 		if (resolved.isEmpty() && specDef.defaultVal().length != 0) {
@@ -204,7 +228,7 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 		}
 		return resolved;
 	}
-	
+
 	private String evaluateRawSpELValue(String rawSpELValue) {
 		try {
 			return embeddedValueResolver.resolveStringValue(rawSpELValue);
@@ -212,7 +236,7 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 			throw new IllegalArgumentException("Invalid SpEL expression: '" + rawSpELValue + "'", e);
 		}
 	}
-	
+
 	private Collection<String> resolveSpecArgumentsFromPathVariables(ProcessingContext context, Spec specDef) {
 		Collection<String> args = new ArrayList<>();
 		for (String pathVar : specDef.pathVars()) {
@@ -223,13 +247,13 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 		}
 		return args;
 	}
-	
+
 	private Collection<String> resolveSpecArgumentsFromBody(ProcessingContext context, Spec specDef) {
 		return Arrays.stream(specDef.jsonPaths())
 				.flatMap(param -> nullSafeArrayStream(context.getBodyParamValues(param)))
 				.collect(toList());
 	}
-	
+
 	private Collection<String> resolveSpecArgumentsFromRequestHeaders(ProcessingContext context, Spec specDef) {
 		Collection<String> args = new ArrayList<>();
 		for (String headerKey : specDef.headers()) {
@@ -241,12 +265,12 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 		}
 		return args;
 	}
-	
+
 	private Collection<String> resolveSpecArgumentsFromHttpParameters(ProcessingContext context, Spec specDef) {
 		Collection<String> args = new ArrayList<String>();
-		
+
 		DelimitationStrategy delimitationStrategy = DelimitationStrategy.of(specDef.paramSeparator());
-		
+
 		if (specDef.params().length != 0) {
 			for (String webParamName : specDef.params()) {
 				if (embeddedValueResolver != null && specDef.paramsInSpEL()) {
@@ -265,10 +289,10 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 				addValuesToArgs(httpParamValues, args);
 			}
 		}
-		
+
 		return args;
 	}
-	
+
 	private void addValuesToArgs(String[] paramValues, Collection<String> args) {
 		if (paramValues != null) {
 			for (String paramValue : paramValues) {
@@ -278,53 +302,53 @@ class SimpleSpecificationResolver implements SpecificationResolver<Spec> {
 			}
 		}
 	}
-	
+
 	private Stream<String> nullSafeArrayStream(String[] array) {
 		return array != null ? Stream.of(array) : Stream.empty();
 	}
-	
+
 	private static class DelimitationStrategy {
-		
+
 		public static final DelimitationStrategy NONE = new DelimitationStrategy("");
-		
+
 		private final String pattern;
-		
+
 		private DelimitationStrategy(String pattern) {
 			this.pattern = pattern;
 		}
-		
+
 		public static DelimitationStrategy of(char paramSeparator) {
 			// 0 is a blank value of param separator
 			if (paramSeparator == 0) {
 				return DelimitationStrategy.NONE;
 			}
-			
+
 			return new DelimitationStrategy(Pattern.quote(String.valueOf(paramSeparator)));
 		}
-		
+
 		public String[] extractSingularValues(String[] args) {
 			if (isEmpty()) {
 				return args;
 			}
-			
+
 			ArrayList<String> listOfSingularValues = new ArrayList<>();
-			
+
 			for (String arg : args) {
 				listOfSingularValues.addAll(asList(arg.split(get())));
 			}
-			
+
 			String[] singularValues = new String[listOfSingularValues.size()];
-			
+
 			return listOfSingularValues.toArray(singularValues);
 		}
-		
+
 		public String get() {
 			return pattern;
 		}
-		
+
 		public boolean isEmpty() {
 			return pattern.isEmpty();
 		}
 	}
-	
+
 }

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationArgumentResolver.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationArgumentResolver.java
@@ -15,6 +15,7 @@
  */
 package net.kaczmarzyk.spring.data.jpa.web;
 
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.core.MethodParameter;
@@ -36,59 +37,85 @@ import java.util.Locale;
 public class SpecificationArgumentResolver implements HandlerMethodArgumentResolver {
 
 	private static final IgnoreCaseStrategy DEFAULT_IGNORE_CASE_STRATEGY = IgnoreCaseStrategy.DATABASE_UPPER;
-	
-	private SpecificationFactory specificationFactory;
+	private static final CharEscaper DEFAULT_CHAR_ESCAPER = CharEscaper.DISABLED;
+
+	private final SpecificationFactory specificationFactory;
 
 	public SpecificationArgumentResolver() {
-		 this(null, null, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY);
+		 this(null, null, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY, DEFAULT_CHAR_ESCAPER);
 	}
-	
+
 	public SpecificationArgumentResolver(ConversionService conversionService) {
-		this(conversionService, null, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY);
+		this(conversionService, null, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY, DEFAULT_CHAR_ESCAPER);
 	}
-	
+
 	public SpecificationArgumentResolver(ConversionService conversionService, Locale defaultLocale) {
-		this(conversionService, null, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY);
+		this(conversionService, null, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY, DEFAULT_CHAR_ESCAPER);
 	}
-	
+
 	public SpecificationArgumentResolver(ConversionService conversionService, AbstractApplicationContext abstractApplicationContext) {
-		this(conversionService, abstractApplicationContext, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY);
+		this(conversionService, abstractApplicationContext, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY, DEFAULT_CHAR_ESCAPER);
 	}
-	
+
 	public SpecificationArgumentResolver(Locale defaultLocale) {
-		this(null, null, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY);
+		this(null, null, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY, DEFAULT_CHAR_ESCAPER);
 	}
-	
+
 	public SpecificationArgumentResolver(AbstractApplicationContext applicationContext) {
-		this(null, applicationContext, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY);
+		this(null, applicationContext, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY, DEFAULT_CHAR_ESCAPER);
 	}
-	
+
 	public SpecificationArgumentResolver(AbstractApplicationContext applicationContext, Locale defaultLocale) {
-		this(null, applicationContext, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY);
+		this(null, applicationContext, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY, DEFAULT_CHAR_ESCAPER);
 	}
 
 	public SpecificationArgumentResolver(ConversionService conversionService, AbstractApplicationContext abstractApplicationContext, Locale defaultLocale) {
-		this(conversionService, abstractApplicationContext, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY);
+		this(conversionService, abstractApplicationContext, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY, DEFAULT_CHAR_ESCAPER);
 	}
 
 	public SpecificationArgumentResolver(IgnoreCaseStrategy ignoreCaseStrategy) {
-		this(null, null, Locale.getDefault(), ignoreCaseStrategy);
+		this(null, null, Locale.getDefault(), ignoreCaseStrategy, DEFAULT_CHAR_ESCAPER);
 	}
 
 	public SpecificationArgumentResolver(ConversionService conversionService, IgnoreCaseStrategy ignoreCaseStrategy) {
-		this(conversionService, null, Locale.getDefault(), ignoreCaseStrategy);
+		this(conversionService, null, Locale.getDefault(), ignoreCaseStrategy, DEFAULT_CHAR_ESCAPER);
 	}
 
 	public SpecificationArgumentResolver(AbstractApplicationContext applicationContext, IgnoreCaseStrategy ignoreCaseStrategy) {
-		this(null, applicationContext, Locale.getDefault(), ignoreCaseStrategy);
+		this(null, applicationContext, Locale.getDefault(), ignoreCaseStrategy, DEFAULT_CHAR_ESCAPER);
+	}
+
+	public SpecificationArgumentResolver(CharEscaper charEscaper) {
+		this(null, null, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY, charEscaper);
+	}
+
+	public SpecificationArgumentResolver(ConversionService conversionService, CharEscaper charEscaper) {
+		this(conversionService, null, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY, charEscaper);
+	}
+
+	public SpecificationArgumentResolver(AbstractApplicationContext applicationContext, CharEscaper charEscaper) {
+		this(null, applicationContext, Locale.getDefault(), DEFAULT_IGNORE_CASE_STRATEGY, charEscaper);
+	}
+
+	public SpecificationArgumentResolver(Locale defaultLocale, CharEscaper charEscaper) {
+		this(null, null, defaultLocale, DEFAULT_IGNORE_CASE_STRATEGY, charEscaper);
+	}
+
+	public SpecificationArgumentResolver(IgnoreCaseStrategy ignoreCaseStrategy, CharEscaper charEscaper) {
+		this(null, null, Locale.getDefault(), ignoreCaseStrategy, charEscaper);
+	}
+
+	public SpecificationArgumentResolver(ConversionService conversionService, AbstractApplicationContext applicationContext,
+	                                     Locale defaultLocale, IgnoreCaseStrategy ignoreCaseStrategy) {
+		this(conversionService, applicationContext, defaultLocale, ignoreCaseStrategy, DEFAULT_CHAR_ESCAPER);
 	}
 
 	public SpecificationArgumentResolver(ConversionService conversionService, AbstractApplicationContext abstractApplicationContext,
-	                                     Locale defaultLocale, IgnoreCaseStrategy ignoreCaseStrategy) {
+										 Locale defaultLocale, IgnoreCaseStrategy ignoreCaseStrategy, CharEscaper charEscaper) {
 		IgnoreCaseStrategy effectiveStrategy = ignoreCaseStrategy != null ? ignoreCaseStrategy : DEFAULT_IGNORE_CASE_STRATEGY;
-		this.specificationFactory = new SpecificationFactory(conversionService, abstractApplicationContext, defaultLocale, effectiveStrategy);
+		CharEscaper effectiveCharEscaper = charEscaper != null ? charEscaper : DEFAULT_CHAR_ESCAPER;
+		this.specificationFactory = new SpecificationFactory(conversionService, abstractApplicationContext, defaultLocale, effectiveStrategy, effectiveCharEscaper);
 	}
-	
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {

--- a/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
+++ b/src/main/java/net/kaczmarzyk/spring/data/jpa/web/SpecificationFactory.java
@@ -15,6 +15,7 @@
  */
 package net.kaczmarzyk.spring.data.jpa.web;
 
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
 import net.kaczmarzyk.spring.data.jpa.utils.TypeUtil;
 import org.springframework.context.support.AbstractApplicationContext;
@@ -35,13 +36,14 @@ import static java.util.stream.Collectors.toMap;
  */
 public class SpecificationFactory {
 
-	private Map<Class<? extends Annotation>, SpecificationResolver<? extends Annotation>> resolversBySupportedType;
+	private final Map<Class<? extends Annotation>, SpecificationResolver<? extends Annotation>> resolversBySupportedType;
 
 	public SpecificationFactory(
 			ConversionService conversionService,
 			AbstractApplicationContext abstractApplicationContext,
 			Locale defaultLocale,
-			IgnoreCaseStrategy defaultIgnoreCaseStrategy
+			IgnoreCaseStrategy defaultIgnoreCaseStrategy,
+			CharEscaper defaultCharEscaper
 	) {
 		if (defaultIgnoreCaseStrategy == null) {
 			throw new IllegalArgumentException("IgnoreCaseStrategy must not be null");
@@ -50,7 +52,8 @@ public class SpecificationFactory {
 				conversionService,
 				abstractApplicationContext,
 				defaultLocale,
-				defaultIgnoreCaseStrategy
+				defaultIgnoreCaseStrategy,
+				defaultCharEscaper
 		);
 
 		resolversBySupportedType = Arrays.asList(

--- a/src/test/java/net/kaczmarzyk/CharEscapingE2eTest.java
+++ b/src/test/java/net/kaczmarzyk/CharEscapingE2eTest.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright 2014-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk;
+
+import net.kaczmarzyk.spring.data.jpa.Customer;
+import net.kaczmarzyk.spring.data.jpa.CustomerRepository;
+import net.kaczmarzyk.spring.data.jpa.domain.*;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Sebastian Nawrocki
+ */
+public class CharEscapingE2eTest extends E2eTestBase {
+
+    @Controller
+    public static class CharEscapingSpecController {
+
+        @Autowired
+        CustomerRepository customerRepo;
+
+        @RequestMapping(value = "/char-escaping-like", params = "lastName")
+        @ResponseBody
+        public Object findCustomersByLastName(
+                @Spec(path = "lastName", spec = Like.class, config = "\\%_") Specification<Customer> spec) {
+
+            return customerRepo.findAll(spec);
+        }
+
+        @RequestMapping(value = "/char-escaping-like-ignore-case", params = "lastName")
+        @ResponseBody
+        public Object findCustomersByLastNameIgnoreCase(
+                @Spec(path = "lastName", spec = LikeIgnoreCase.class, config = {"en_US", "\\%_"}) Specification<Customer> spec) {
+
+            return customerRepo.findAll(spec);
+        }
+
+        @RequestMapping(value = "/char-escaping-not-like", params = "lastName")
+        @ResponseBody
+        public Object findCustomersByLastNameNotLike(
+                @Spec(path = "lastName", spec = NotLike.class, config = "\\%_") Specification<Customer> spec) {
+
+            return customerRepo.findAll(spec);
+        }
+
+        @RequestMapping(value = "/char-escaping-not-like-ignore-case", params = "lastName")
+        @ResponseBody
+        public Object findCustomersByLastNameNotLikeIgnoreCase(
+                @Spec(path = "lastName", spec = NotLikeIgnoreCase.class, config = {"en_US", "\\%_"}) Specification<Customer> spec) {
+
+            return customerRepo.findAll(spec);
+        }
+
+        @RequestMapping(value = "/char-escaping-starting-with", params = "lastName")
+        @ResponseBody
+        public Object findCustomersByLastNameStartingWith(
+                @Spec(path = "lastName", spec = StartingWith.class, config = "\\%_") Specification<Customer> spec) {
+
+            return customerRepo.findAll(spec);
+        }
+
+        @RequestMapping(value = "/char-escaping-starting-with-ignore-case", params = "lastName")
+        @ResponseBody
+        public Object findCustomersByLastNameStartingWithIgnoreCase(
+                @Spec(path = "lastName", spec = StartingWithIgnoreCase.class, config = {"en_US", "\\%_"}) Specification<Customer> spec) {
+
+            return customerRepo.findAll(spec);
+        }
+
+        @RequestMapping(value = "/char-escaping-ending-with", params = "lastName")
+        @ResponseBody
+        public Object findCustomersByLastNameEndingWith(
+                @Spec(path = "lastName", spec = EndingWith.class, config = "\\%_") Specification<Customer> spec) {
+
+            return customerRepo.findAll(spec);
+        }
+
+        @RequestMapping(value = "/char-escaping-ending-with-ignore-case", params = "lastName")
+        @ResponseBody
+        public Object findCustomersByLastNameEndingWithIgnoreCase(
+                @Spec(path = "lastName", spec = EndingWithIgnoreCase.class, config = {"en_US", "\\%_"}) Specification<Customer> spec) {
+
+            return customerRepo.findAll(spec);
+        }
+    }
+
+    @BeforeEach
+    public void initData() {
+        customer("any", "percent%").build(em);
+        customer("any", "apercent").build(em); // would match percent% if % was wildcard
+
+        customer("any", "underscore_").build(em);
+        customer("any", "aunderscore").build(em); // would match underscore_ if _ was wildcard
+
+        customer("any", "%beginning").build(em);
+        customer("any", "xbeginning").build(em); // would match %beginning if % was wildcard
+
+        customer("any", "_beginning").build(em);
+        customer("any", "ybeginning").build(em); // would match _beginning if _ was wildcard
+
+        customer("any", "mi%ddle").build(em);
+        customer("any", "mi_ddle").build(em);
+        customer("any", "mieddle").build(em); // would match mi_ddle if _ was wildcard
+
+        customer("any", "combo%_").build(em);
+        customer("any", "comboxx").build(em); // would match combo%_ if wildcards
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedPercentSignAtEnd() throws Exception {
+        mockMvc.perform(get("/char-escaping-like")
+                        .param("lastName", "percent%")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("percent%"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedPercentSignAtBeginning() throws Exception {
+        mockMvc.perform(get("/char-escaping-like")
+                        .param("lastName", "%beginning")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("%beginning"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedPercentSignInMiddle() throws Exception {
+        mockMvc.perform(get("/char-escaping-like")
+                        .param("lastName", "mi%ddle")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("mi%ddle"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedUnderscoreAtEnd() throws Exception {
+        mockMvc.perform(get("/char-escaping-like")
+                        .param("lastName", "underscore_")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("underscore_"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedUnderscoreAtBeginning() throws Exception {
+        mockMvc.perform(get("/char-escaping-like")
+                        .param("lastName", "_beginning")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("_beginning"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedUnderscoreInMiddle() throws Exception {
+        mockMvc.perform(get("/char-escaping-like")
+                        .param("lastName", "mi_ddle")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("mi_ddle"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedComboOfBothCharacters() throws Exception {
+        mockMvc.perform(get("/char-escaping-like")
+                        .param("lastName", "combo%_")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("combo%_"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedPercentSignIgnoreCase() throws Exception {
+        mockMvc.perform(get("/char-escaping-like-ignore-case")
+                        .param("lastName", "PERCENT%")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("percent%"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameNotLikeWithEscapedPercentSign() throws Exception {
+        mockMvc.perform(get("/char-escaping-not-like")
+                        .param("lastName", "percent%")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[*].lastName").value(not(hasItem("percent%"))));
+    }
+
+    @Test
+    public void findsByLastNameNotLikeIgnoreCaseWithEscapedPercentSign() throws Exception {
+        mockMvc.perform(get("/char-escaping-not-like-ignore-case")
+                        .param("lastName", "PERCENT%")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[*].lastName").value(not(hasItem("percent%"))));
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedPercentSignStartingWith() throws Exception {
+        mockMvc.perform(get("/char-escaping-starting-with")
+                        .param("lastName", "percent%")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("percent%"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedPercentSignStartingWithIgnoreCase() throws Exception {
+        mockMvc.perform(get("/char-escaping-starting-with-ignore-case")
+                        .param("lastName", "PERCENT%")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("percent%"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedPercentSignEndingWith() throws Exception {
+        mockMvc.perform(get("/char-escaping-ending-with")
+                        .param("lastName", "percent%")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("percent%"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    public void findsByLastNameWithEscapedPercentSignEndingWithIgnoreCase() throws Exception {
+        mockMvc.perform(get("/char-escaping-ending-with-ignore-case")
+                        .param("lastName", "PERCENT%")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].lastName").value("percent%"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+}
+

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWithIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWithIgnoreCaseTest.java
@@ -17,14 +17,14 @@ package net.kaczmarzyk.spring.data.jpa.domain;
 
 import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Locale;
+import java.util.Set;
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +55,22 @@ public class EndingWithIgnoreCaseTest extends IntegrationTestBase {
 		EndingWithIgnoreCase<Customer> firstNameWithO = new EndingWithIgnoreCase<>(queryCtx, "firstName", "ER");
 		result = customerRepo.findAll(firstNameWithO);
 		assertThat(result).hasSize(1).containsOnly(homerSimpson);
+	}
+
+	@Test
+	public void usesCharEscaper() {
+		customer("any", "Prefix%Char").build(em);
+		customer("any", "Prefix_Char").build(em);
+
+		EndingWithIgnoreCase<Customer> spec = new EndingWithIgnoreCase<>(queryCtx, "lastName", "%CHAR");
+		spec.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+		List<Customer> result = customerRepo.findAll(spec);
+
+		assertThat(result)
+				.hasSize(1)
+				.extracting(Customer::getLastName)
+				.containsOnly("Prefix%Char");
 	}
 
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWithTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/EndingWithTest.java
@@ -17,12 +17,14 @@ package net.kaczmarzyk.spring.data.jpa.domain;
 
 import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,6 +55,22 @@ public class EndingWithTest extends IntegrationTestBase {
 		EndingWith<Customer> firstNameWithO = new EndingWith<>(queryCtx, "firstName", "er");
 		result = customerRepo.findAll(firstNameWithO);
 		assertThat(result).hasSize(1).containsOnly(homerSimpson);
+	}
+
+	@Test
+	public void usesCharEscaper() {
+		customer("any", "Prefix%Char").build(em);
+		customer("any", "Prefix_Char").build(em);
+
+		EndingWith<Customer> spec = new EndingWith<>(queryCtx, "lastName", "%Char");
+		spec.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+		List<Customer> result = customerRepo.findAll(spec);
+
+		assertThat(result)
+				.hasSize(1)
+				.extracting(Customer::getLastName)
+				.containsOnly("Prefix%Char");
 	}
 
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/LikeIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/LikeIgnoreCaseTest.java
@@ -17,14 +17,14 @@ package net.kaczmarzyk.spring.data.jpa.domain;
 
 import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Locale;
+import java.util.Set;
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +61,22 @@ public class LikeIgnoreCaseTest extends IntegrationTestBase {
         assertThat(result)
             .hasSize(2)
             .containsOnly(homerSimpson, moeSzyslak);
+    }
+
+    @Test
+    public void usesCharEscaper() {
+        customer("any", "Char%").build(em);
+        customer("any", "Char_").build(em);
+
+        LikeIgnoreCase<Customer> spec = new LikeIgnoreCase<>(queryCtx, "lastName", "CHAR%");
+        spec.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+        List<Customer> result = customerRepo.findAll(spec);
+
+        assertThat(result)
+                .hasSize(1)
+                .extracting(Customer::getLastName)
+                .containsOnly("Char%");
     }
 
     @Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/LikeTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/LikeTest.java
@@ -18,13 +18,14 @@ package net.kaczmarzyk.spring.data.jpa.domain;
 import com.jparams.verifier.tostring.ToStringVerifier;
 import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,6 +61,22 @@ public class LikeTest extends IntegrationTestBase {
         assertThat(result)
             .hasSize(2)
             .containsOnly(homerSimpson, moeSzyslak);
+    }
+
+    @Test
+    public void usesCharEscaper() {
+        customer("any", "Combo%_Char").build(em);
+        customer("any", "Other_Char").build(em);
+
+        Like<Customer> spec = new Like<>(queryCtx, "lastName", "Combo%_Char");
+        spec.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+        List<Customer> result = customerRepo.findAll(spec);
+
+        assertThat(result)
+                .hasSize(1)
+                .extracting(Customer::getLastName)
+                .containsOnly("Combo%_Char");
     }
 
     @Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeIgnoreCaseTest.java
@@ -17,14 +17,14 @@ package net.kaczmarzyk.spring.data.jpa.domain;
 
 import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Locale;
+import java.util.Set;
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,6 +56,21 @@ public class NotLikeIgnoreCaseTest extends IntegrationTestBase {
         assertThat(result)
                 .hasSize(1)
                 .containsOnly(margeSimpson);
+    }
+
+    @Test
+    public void usesCharEscaper() {
+        customer("any", "Char%").build(em);
+        customer("any", "Char_").build(em);
+
+        NotLikeIgnoreCase<Customer> spec = new NotLikeIgnoreCase<>(queryCtx, "lastName", "CHAR%");
+        spec.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+        List<Customer> result = customerRepo.findAll(spec);
+
+        assertThat(result)
+                .extracting(Customer::getLastName)
+                .containsOnly("Simpson", "Szyslak", "Char_");
     }
 
     @Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/NotLikeTest.java
@@ -18,13 +18,14 @@ package net.kaczmarzyk.spring.data.jpa.domain;
 import com.jparams.verifier.tostring.ToStringVerifier;
 import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,6 +61,21 @@ public class NotLikeTest extends IntegrationTestBase {
         assertThat(result)
             .hasSize(1)
             .containsOnly(margeSimpson);
+    }
+
+    @Test
+    public void usesCharEscaper() {
+        customer("any", "Char%").build(em);
+        customer("any", "Char_").build(em);
+
+        NotLike<Customer> spec = new NotLike<>(queryCtx, "lastName", "Char%");
+        spec.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+        List<Customer> result = customerRepo.findAll(spec);
+
+        assertThat(result)
+                .extracting(Customer::getLastName)
+                .containsOnly("Simpson", "Szyslak", "Char_");
     }
 
     @Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/StartingWithIgnoreCaseTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/StartingWithIgnoreCaseTest.java
@@ -17,14 +17,14 @@ package net.kaczmarzyk.spring.data.jpa.domain;
 
 import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Locale;
+import java.util.Set;
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,6 +58,22 @@ public class StartingWithIgnoreCaseTest extends IntegrationTestBase {
 		StartingWithIgnoreCase<Customer> firstNameWithO = new StartingWithIgnoreCase<>(queryCtx, "firstName", "HO");
 		result = customerRepo.findAll(firstNameWithO);
 		assertThat(result).hasSize(1).containsOnly(homerSimpson);
+	}
+
+	@Test
+	public void usesCharEscaper() {
+		customer("any", "Char%Suffix").build(em);
+		customer("any", "Char_Suffix").build(em);
+
+		StartingWithIgnoreCase<Customer> spec = new StartingWithIgnoreCase<>(queryCtx, "lastName", "CHAR%");
+		spec.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+		List<Customer> result = customerRepo.findAll(spec);
+
+		assertThat(result)
+				.hasSize(1)
+				.extracting(Customer::getLastName)
+				.containsOnly("Char%Suffix");
 	}
 
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/StartingWithTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/domain/StartingWithTest.java
@@ -17,12 +17,14 @@ package net.kaczmarzyk.spring.data.jpa.domain;
 
 import net.kaczmarzyk.spring.data.jpa.Customer;
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBase;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static net.kaczmarzyk.spring.data.jpa.CustomerBuilder.customer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,6 +55,22 @@ public class StartingWithTest extends IntegrationTestBase {
 		StartingWith<Customer> firstNameWithO = new StartingWith<>(queryCtx, "firstName", "Ho");
 		result = customerRepo.findAll(firstNameWithO);
 		assertThat(result).hasSize(1).containsOnly(homerSimpson);
+	}
+
+	@Test
+	public void usesCharEscaper() {
+		customer("any", "Char%Suffix").build(em);
+		customer("any", "Char_Suffix").build(em);
+
+		StartingWith<Customer> spec = new StartingWith<>(queryCtx, "lastName", "Char%");
+		spec.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+		List<Customer> result = customerRepo.findAll(spec);
+
+		assertThat(result)
+				.hasSize(1)
+				.extracting(Customer::getLastName)
+				.containsOnly("Char%Suffix");
 	}
 
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/CharEscaperTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/CharEscaperTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2014-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Sebastian Nawrocki
+ */
+public class CharEscaperTest {
+
+    @Test
+    public void escapesSpecifiedCharactersAtDifferentPositions() {
+        CharEscaper escaper = new CharEscaper('\\', Set.of('%', '_'));
+
+        assertThat(escaper.escape("%_percent_underscore")).isEqualTo("\\%\\_percent\\_underscore");
+        assertThat(escaper.escape("percent_underscore%_")).isEqualTo("percent\\_underscore\\%\\_");
+        assertThat(escaper.escape("per%cent_und_erscore")).isEqualTo("per\\%cent\\_und\\_erscore");
+        assertThat(escaper.escape("combo%_combo")).isEqualTo("combo\\%\\_combo");
+    }
+
+    @Test
+    public void escapesEscapeCharacterItself() {
+        CharEscaper escaper = new CharEscaper('\\', Set.of('%', '_'));
+
+        assertThat(escaper.escape("escape \\ character")).isEqualTo("escape \\\\ character");
+    }
+
+    @Test
+    public void doesNotEscapeAnythingWhenDisabled() {
+        CharEscaper escaper = CharEscaper.DISABLED;
+
+        assertThat(escaper.escape("percent % and underscore _")).isEqualTo("percent % and underscore _");
+    }
+
+    @Test
+    public void returnsNullWhenValueIsNull() {
+        CharEscaper escaper = new CharEscaper('\\', Set.of('%', '_'));
+
+        assertThat(escaper.escape(null)).isNull();
+    }
+}

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/ReflectionUtilsTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/utils/ReflectionUtilsTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2014-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.kaczmarzyk.spring.data.jpa.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Sebastian Nawrocki
+ */
+public class ReflectionUtilsTest {
+
+    @Test
+    public void executesFirstSuccessfulOperation() throws Exception {
+        String result = ReflectionUtils.tryInstance(
+                () -> { throw new NoSuchMethodException(); },
+                () -> "success",
+                () -> "unreachable"
+        );
+
+        assertThat(result).isEqualTo("success");
+    }
+
+    @Test
+    public void returnsNullIfAllOperationsThrowNoSuchMethodException() throws Exception {
+        String result = ReflectionUtils.tryInstance(
+                () -> { throw new NoSuchMethodException(); },
+                () -> { throw new NoSuchMethodException(); }
+        );
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void throwsOriginalExceptionWhenOperationThrowsOtherException() {
+        assertThatThrownBy(() -> ReflectionUtils.tryInstance(() -> { throw new RuntimeException("inner error"); }))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("inner error");
+    }
+
+    @Test
+    public void throwsOriginalExceptionWhenOperationThrowsCheckedException() {
+        assertThatThrownBy(() -> ReflectionUtils.tryInstance(() -> { throw new Exception("checked error"); }))
+                .isExactlyInstanceOf(Exception.class)
+                .hasMessage("checked error");
+    }
+}

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverConstValueSpELSupportIntegrationTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverConstValueSpELSupportIntegrationTest.java
@@ -16,6 +16,7 @@
 package net.kaczmarzyk.spring.data.jpa.web;
 
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBaseWithSARConfiguredWithApplicationContext;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import net.kaczmarzyk.spring.data.jpa.domain.EmptyResultOnTypeMismatch;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
 import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
@@ -50,7 +51,7 @@ public class SimpleSpecificationResolverConstValueSpELSupportIntegrationTest ext
 	
 	@BeforeEach
 	public void initializeResolver() {
-		this.resolver = new SimpleSpecificationResolver(null, abstractApplicationContext, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER);
+		this.resolver = new SimpleSpecificationResolver(null, abstractApplicationContext, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER, CharEscaper.DISABLED);
 	}
 	
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverDefaultValueIntegrationTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverDefaultValueIntegrationTest.java
@@ -16,6 +16,7 @@
 package net.kaczmarzyk.spring.data.jpa.web;
 
 import net.kaczmarzyk.spring.data.jpa.IntegrationTestBaseWithSARConfiguredWithApplicationContext;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import net.kaczmarzyk.spring.data.jpa.domain.EmptyResultOnTypeMismatch;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
 import net.kaczmarzyk.spring.data.jpa.domain.IgnoreCaseStrategy;
@@ -50,7 +51,7 @@ public class SimpleSpecificationResolverDefaultValueIntegrationTest extends Inte
 	
 	@BeforeEach
 	public void initializeResolver() {
-		this.resolver = new SimpleSpecificationResolver(null, abstractApplicationContext, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER);
+		this.resolver = new SimpleSpecificationResolver(null, abstractApplicationContext, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER, CharEscaper.DISABLED);
 	}
 	
 	@Test

--- a/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverTest.java
+++ b/src/test/java/net/kaczmarzyk/spring/data/jpa/web/SimpleSpecificationResolverTest.java
@@ -16,11 +16,11 @@
 package net.kaczmarzyk.spring.data.jpa.web;
 
 import net.kaczmarzyk.spring.data.jpa.domain.*;
+import net.kaczmarzyk.spring.data.jpa.utils.CharEscaper;
 import net.kaczmarzyk.spring.data.jpa.utils.Converter;
 import net.kaczmarzyk.spring.data.jpa.utils.QueryContext;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.OnTypeMismatch;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
-import net.kaczmarzyk.utils.ReflectionUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.jpa.domain.Specification;
@@ -28,6 +28,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 
 
 import java.util.Locale;
+import java.util.Set;
 
 import static net.kaczmarzyk.spring.data.jpa.web.annotation.OnTypeMismatch.EXCEPTION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -271,19 +272,97 @@ public class SimpleSpecificationResolverTest extends ResolverTestBase {
     }
 
     @Test
-    public void shouldThrowIllegalStateExceptionWhenSpecConfigLengthIsMoreThanOne(){
-        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethod11"), 0);
+    public void buildsSpecUsingCharEscaperConfigWhenMoreThanOneConfigValueIsPresentForLocaleAwareSpec() {
+        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethodWithLocaleAndCharEscaperConfig"), 0);
         NativeWebRequest req = mock(NativeWebRequest.class);
 
-        when(req.getParameterValues("theParameter")).thenReturn(new String[] {"example"});
+        when(req.getParameterValues("theParameter")).thenReturn(new String[]{"example"});
 
         WebRequestProcessingContext ctx = new WebRequestProcessingContext(param, req);
 
-        assertThatThrownBy(() -> resolver.buildSpecification(ctx, param.getParameterAnnotation(Spec.class)))
-        		.isInstanceOf(IllegalStateException.class);
+        Specification<Object> resolved = resolver.buildSpecification(ctx, param.getParameterAnnotation(Spec.class));
+
+        LikeIgnoreCase<Object> expected = new LikeIgnoreCase<>(ctx.queryContext(), "thePath", "example");
+        expected.setLocale(new Locale("pl", "PL"));
+        expected.setIgnoreCaseStrategy(IgnoreCaseStrategy.DATABASE_UPPER);
+        expected.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+        assertThat(resolved).isEqualTo(expected);
     }
 
-    
+    @Test
+    public void buildsSpecUsingCharEscaperConfigWhenConfigIsPresentForNonLocaleAwareSpec() {
+        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethodWithCharEscaperConfig"), 0);
+        NativeWebRequest req = mock(NativeWebRequest.class);
+
+        when(req.getParameterValues("theParameter")).thenReturn(new String[]{"example"});
+
+        WebRequestProcessingContext ctx = new WebRequestProcessingContext(param, req);
+
+        Specification<Object> resolved = resolver.buildSpecification(ctx, param.getParameterAnnotation(Spec.class));
+
+        Like<Object> expected = new Like<>(ctx.queryContext(), "thePath", "example");
+        expected.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+        assertThat(resolved).isEqualTo(expected);
+    }
+
+    @Test
+    public void buildsSpecUsingGlobalCharEscaperWhenNoLocalConfigIsPresent() {
+        CharEscaper globalEscaper = new CharEscaper('!', Set.of('%'));
+        SimpleSpecificationResolver resolverWithGlobalEscaper = new SimpleSpecificationResolver(null, null, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER, globalEscaper);
+
+        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethod1"), 0);
+        NativeWebRequest req = mock(NativeWebRequest.class);
+        when(req.getParameterValues("thePath")).thenReturn(new String[]{"example"});
+
+        WebRequestProcessingContext ctx = new WebRequestProcessingContext(param, req);
+
+        Specification<Object> resolved = resolverWithGlobalEscaper.buildSpecification(ctx, param.getParameterAnnotation(Spec.class));
+
+        Like<Object> expected = new Like<>(ctx.queryContext(), "thePath", "example");
+        expected.applyCharEscaper(globalEscaper);
+
+        assertThat(resolved).isEqualTo(expected);
+    }
+
+    @Test
+    public void buildsSpecUsingLocalCharEscaperWhenGlobalEscaperIsPresent() {
+        CharEscaper globalEscaper = new CharEscaper('!', Set.of('%'));
+        SimpleSpecificationResolver resolverWithGlobalEscaper = new SimpleSpecificationResolver(null, null, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER, globalEscaper);
+
+        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethodWithCharEscaperConfig"), 0);
+        NativeWebRequest req = mock(NativeWebRequest.class);
+        when(req.getParameterValues("theParameter")).thenReturn(new String[]{"example"});
+
+        WebRequestProcessingContext ctx = new WebRequestProcessingContext(param, req);
+
+        Specification<Object> resolved = resolverWithGlobalEscaper.buildSpecification(ctx, param.getParameterAnnotation(Spec.class));
+
+        Like<Object> expected = new Like<>(ctx.queryContext(), "thePath", "example");
+        expected.applyCharEscaper(new CharEscaper('\\', Set.of('%', '_')));
+
+        assertThat(resolved).isEqualTo(expected);
+    }
+
+    @Test
+    public void buildsSpecWithoutCharEscaperWhenExplicitlyDisabledLocallyEvenIfGlobalEscaperIsPresent() {
+        CharEscaper globalEscaper = new CharEscaper('!', Set.of('%'));
+        SimpleSpecificationResolver resolverWithGlobalEscaper = new SimpleSpecificationResolver(null, null, Locale.getDefault(), IgnoreCaseStrategy.DATABASE_UPPER, globalEscaper);
+
+        MethodParameter param = MethodParameter.forExecutable(testMethod("testMethodWithExplicitlyDisabledCharEscaperConfig"), 0);
+        NativeWebRequest req = mock(NativeWebRequest.class);
+        when(req.getParameterValues("theParameter")).thenReturn(new String[]{"example"});
+
+        WebRequestProcessingContext ctx = new WebRequestProcessingContext(param, req);
+
+        Specification<Object> resolved = resolverWithGlobalEscaper.buildSpecification(ctx, param.getParameterAnnotation(Spec.class));
+
+        Like<Object> expected = new Like<>(ctx.queryContext(), "thePath", "example");
+        expected.applyCharEscaper(CharEscaper.DISABLED);
+
+        assertThat(resolved).isEqualTo(expected);
+    }
 
     public static class TestController {
 
@@ -324,8 +403,16 @@ public class SimpleSpecificationResolverTest extends ResolverTestBase {
                 @Spec(path = "thePath", params = "theParameter", paramSeparator = ',', spec = Equal.class, onTypeMismatch = EXCEPTION) Specification<Object> spec) {
         }
 
-        public void testMethod11(
-                @Spec(path = "thePath", params = "theParameter", paramSeparator = ',', spec = Equal.class, onTypeMismatch = EXCEPTION, config = {"config1", "config2"}) Specification<Object> spec) {
+        public void testMethodWithLocaleAndCharEscaperConfig(
+                @Spec(path = "thePath", params = "theParameter", spec = LikeIgnoreCase.class, config = {"pl_PL", "\\%_"}, onTypeMismatch = EXCEPTION) Specification<Object> spec) {
+        }
+
+        public void testMethodWithCharEscaperConfig(
+                @Spec(path = "thePath", params = "theParameter", spec = Like.class, config = "\\%_", onTypeMismatch = EXCEPTION) Specification<Object> spec) {
+        }
+
+        public void testMethodWithExplicitlyDisabledCharEscaperConfig(
+                @Spec(path = "thePath", params = "theParameter", spec = Like.class, config = "", onTypeMismatch = EXCEPTION) Specification<Object> spec) {
         }
 
         public void testMethodWithLocaleAwareSpec(


### PR DESCRIPTION
## Description
Adds character escaping support for LIKE-based specifications to safely handle special characters like `%` and `_`. 

These changes are intended for both `3.x` and `4.x` branches. Please merge into both. I can help with any necessary adjustments for `4.x`.

## Key Changes
* `CharEscapeAware` interface: Implemented by `Like`, `StartingWith`, `EndingWith`, `NotLike` and their `IgnoreCase` variants.
* `CharEscaper` utility: Handles special character escaping logic.
* Flexible Configuration:
  * Global: Configured during `SpecificationArgumentResolver` registration.
  * Local: Overridden per `@Spec` using the `config` attribute.
* Backward Compatibility: The `config` attribute now supports arrays for `LocaleAware` and `CharEscapeAware` specifications.

## Important Notes
* Disabled by default: Escaping is disabled by default (`CharEscaper.DISABLED`) to maintain backward compatibility.
* Database dialect: Users must provide an escape character and characters to escape compatible with their database.

## Documentation
* Updated `README.md` with a "Character escaping support" section.
* Updated `CHANGELOG.md` for version 3.4.0.